### PR TITLE
Add reading status tools, title search, and limit parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Model Context Protocol (MCP) server for Apple Books.
 ## At a glance
 
 * Ask Claude to summarize your recent highlights
+* Ask Claude what books you're currently reading and your progress
+* Ask Claude to find a book by title
 * Ask Claude to organize books in your library by genre
 * Ask Claude to recommend similar books based on your reading history
 * Ask Claude to compare notes from different books read on the same subject
@@ -21,21 +23,44 @@ And much more!
 
 ## Available Tools
 
+### Collections
+
 | Tool | Description | Parameters |
-|----------|-------------|------------|
-| list_collections() | List all collections | None |
-| get_collection_books(collection_id) | Get all books in a collection | collection_id: str |
-| describe_collection(collection_id) | Get details of a collection | collection_id: str |
-| list_all_books() | List all books | None |
-| get_book_annotations(book_id) | Get all annotations for a book | book_id: str |
-| describe_book(book_id) | Get details of a particular book | book_id: str |
-| list_all_annotations() | List all annotations | None |
-| get_highlights_by_color(color) | Get all highlights by color | color: str |
-| search_highlighted_text(text) | Search for highlights by highlighted text | text: str |
-| search_notes(note) | Search for notes | note: str |
-| full_text_search(text) | Search for annotations containing the given text | text: str |
-| recent_annotations() | Get 10 most recent annotations | None |
-| describe_annotation(annotation_id) | Get details of an annotation | annotation_id: str |
+|------|-------------|------------|
+| list_all_collections | List all collections | limit?: int |
+| get_collection_books | Get all books in a collection | collection_id: str |
+| describe_collection | Get details of a collection | collection_id: str |
+| search_collections_by_title | Search for collections by title | title: str |
+
+### Books
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| list_all_books | List all books | limit?: int |
+| describe_book | Get details of a particular book | book_id: str |
+| get_book_annotations | Get all annotations for a book | book_id: str |
+| search_books_by_title | Search for books by title | title: str |
+
+### Reading Status
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_books_in_progress | Get books currently being read | limit?: int |
+| get_finished_books | Get books that have been finished | limit?: int |
+| get_unstarted_books | Get books not yet started | limit?: int |
+| get_recently_read_books | Get most recently opened books | limit?: int (default: 10) |
+
+### Annotations
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| list_all_annotations | List all annotations | limit?: int |
+| recent_annotations | Get most recent annotations | limit?: int (default: 10) |
+| describe_annotation | Get details of an annotation | annotation_id: str |
+| get_highlights_by_color | Get all highlights by color | color: str, limit?: int |
+| search_highlighted_text | Search highlights by text | text: str, limit?: int |
+| search_notes | Search annotations by note | note: str, limit?: int |
+| full_text_search | Search annotations by any text | text: str, limit?: int |
 
 ## Installation
 

--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 
 @click.command()

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -124,6 +124,38 @@ def describe_book(book_id: str) -> TextContent:
     )
 
 
+@mcp.tool()
+def search_books_by_title(title: str) -> TextContent:
+    """
+    Search for books by title.
+
+    Args:
+        title: The title to search for.
+    """
+    books = apple_books.get_book_by_title(title)
+    books_str = "\n".join([f"{str(book)}\n" for book in books])
+    return TextContent(
+        type="text",
+        text=f"Books:\n{books_str}"
+    )
+
+
+@mcp.tool()
+def search_collections_by_title(title: str) -> TextContent:
+    """
+    Search for collections by title.
+
+    Args:
+        title: The title to search for.
+    """
+    collections = apple_books.get_collection_by_title(title)
+    collections_str = "\n".join([f"{str(collection)}\n" for collection in collections])
+    return TextContent(
+        type="text",
+        text=f"Collections:\n{collections_str}"
+    )
+
+
 # -- Reading Status Tools --
 @mcp.tool()
 def get_books_in_progress() -> TextContent:

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -12,6 +12,13 @@ mcp = FastMCP("apple-books")
 apple_books = PyAppleBooks()
 
 
+def _format_book_with_progress(book) -> str:
+    author = getattr(book, "author", None) or "Unknown Author"
+    title = getattr(book, "title", None) or "Unknown Title"
+    progress = book.format_progress_summary()
+    return f"{title} by {author}\n{progress}"
+
+
 def _get_book_title(annotation) -> str:
     book = getattr(annotation, "book", None)
     return getattr(book, "title", None) or "Unknown Book"
@@ -114,6 +121,63 @@ def describe_book(book_id: str) -> TextContent:
     return TextContent(
         type="text",
         text=f"{json.dumps(book.__dict__, default=str)}"
+    )
+
+
+# -- Reading Status Tools --
+@mcp.tool()
+def get_books_in_progress() -> TextContent:
+    """Get all books currently being read (progress > 0% and < 100%)."""
+    books = apple_books.get_books_in_progress()
+    books_str = "\n".join([
+        _format_book_with_progress(book)
+        for book in books
+    ])
+    return TextContent(
+        type="text",
+        text=f"Books in progress:\n{books_str}"
+    )
+
+
+@mcp.tool()
+def get_finished_books() -> TextContent:
+    """Get all books that have been finished."""
+    books = apple_books.get_finished_books()
+    books_str = "\n".join([
+        _format_book_with_progress(book)
+        for book in books
+    ])
+    return TextContent(
+        type="text",
+        text=f"Finished books:\n{books_str}"
+    )
+
+
+@mcp.tool()
+def get_unstarted_books() -> TextContent:
+    """Get all books that haven't been started yet (0% progress)."""
+    books = apple_books.get_unstarted_books()
+    books_str = "\n".join([
+        _format_book_with_progress(book)
+        for book in books
+    ])
+    return TextContent(
+        type="text",
+        text=f"Unstarted books:\n{books_str}"
+    )
+
+
+@mcp.tool()
+def get_recently_read_books() -> TextContent:
+    """Get 10 most recently opened books, ordered by last opened date."""
+    books = apple_books.get_recently_read_books()
+    books_str = "\n".join([
+        _format_book_with_progress(book)
+        for book in books
+    ])
+    return TextContent(
+        type="text",
+        text=f"Recently read books:\n{books_str}"
     )
 
 

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -37,9 +37,14 @@ def _format_annotation_with_book(annotation, include_chapter: bool = False) -> s
 
 # -- Collections Tools --
 @mcp.tool()
-def list_all_collections() -> TextContent:
-    """List all collections in my Apple Books library."""
-    collections = apple_books.list_collections()
+def list_all_collections(limit: int = None) -> TextContent:
+    """
+    List all collections in my Apple Books library.
+
+    Args:
+        limit: Maximum number of collections to return.
+    """
+    collections = apple_books.list_collections(limit=limit)
     collections_str = "\n".join([f"{str(collection)}\n" for collection in collections])
     return TextContent(
         type="text",
@@ -80,9 +85,14 @@ def describe_collection(collection_id: str) -> TextContent:
 
 # -- Books Tools --
 @mcp.tool()
-def list_all_books() -> TextContent:
-    """List all books in my Apple Books library."""
-    books = apple_books.list_books()
+def list_all_books(limit: int = None) -> TextContent:
+    """
+    List all books in my Apple Books library.
+
+    Args:
+        limit: Maximum number of books to return.
+    """
+    books = apple_books.list_books(limit=limit)
     books_str = "\n".join([f"{str(book)}\n" for book in books])
     return TextContent(
         type="text",
@@ -158,9 +168,14 @@ def search_collections_by_title(title: str) -> TextContent:
 
 # -- Reading Status Tools --
 @mcp.tool()
-def get_books_in_progress() -> TextContent:
-    """Get all books currently being read (progress > 0% and < 100%)."""
-    books = apple_books.get_books_in_progress()
+def get_books_in_progress(limit: int = None) -> TextContent:
+    """
+    Get all books currently being read (progress > 0% and < 100%).
+
+    Args:
+        limit: Maximum number of books to return.
+    """
+    books = apple_books.get_books_in_progress(limit=limit)
     books_str = "\n".join([
         _format_book_with_progress(book)
         for book in books
@@ -172,9 +187,14 @@ def get_books_in_progress() -> TextContent:
 
 
 @mcp.tool()
-def get_finished_books() -> TextContent:
-    """Get all books that have been finished."""
-    books = apple_books.get_finished_books()
+def get_finished_books(limit: int = None) -> TextContent:
+    """
+    Get all books that have been finished.
+
+    Args:
+        limit: Maximum number of books to return.
+    """
+    books = apple_books.get_finished_books(limit=limit)
     books_str = "\n".join([
         _format_book_with_progress(book)
         for book in books
@@ -186,9 +206,14 @@ def get_finished_books() -> TextContent:
 
 
 @mcp.tool()
-def get_unstarted_books() -> TextContent:
-    """Get all books that haven't been started yet (0% progress)."""
-    books = apple_books.get_unstarted_books()
+def get_unstarted_books(limit: int = None) -> TextContent:
+    """
+    Get all books that haven't been started yet (0% progress).
+
+    Args:
+        limit: Maximum number of books to return.
+    """
+    books = apple_books.get_unstarted_books(limit=limit)
     books_str = "\n".join([
         _format_book_with_progress(book)
         for book in books
@@ -200,9 +225,14 @@ def get_unstarted_books() -> TextContent:
 
 
 @mcp.tool()
-def get_recently_read_books() -> TextContent:
-    """Get 10 most recently opened books, ordered by last opened date."""
-    books = apple_books.get_recently_read_books()
+def get_recently_read_books(limit: int = 10) -> TextContent:
+    """
+    Get most recently opened books, ordered by last opened date.
+
+    Args:
+        limit: Maximum number of books to return. Defaults to 10.
+    """
+    books = apple_books.get_recently_read_books(limit=limit)
     books_str = "\n".join([
         _format_book_with_progress(book)
         for book in books
@@ -215,9 +245,14 @@ def get_recently_read_books() -> TextContent:
 
 # -- Annotations Tools --
 @mcp.tool()
-def list_all_annotations() -> TextContent:
-    """List all my annotations in my Apple Books library."""
-    annotations = apple_books.list_annotations()
+def list_all_annotations(limit: int = None) -> TextContent:
+    """
+    List all my annotations in my Apple Books library.
+
+    Args:
+        limit: Maximum number of annotations to return.
+    """
+    annotations = apple_books.list_annotations(limit=limit)
     annotations_str = "\n".join([
         f"ID: {annotation.id} - Selected Text: {annotation.selected_text}\n"
         for annotation in annotations
@@ -229,14 +264,15 @@ def list_all_annotations() -> TextContent:
 
 
 @mcp.tool()
-def get_highlights_by_color(color: str) -> TextContent:
+def get_highlights_by_color(color: str, limit: int = None) -> TextContent:
     """
     Get all annotations/highlights by color.
 
     Args:
         color: The color of the annotations/highlights.
+        limit: Maximum number of annotations to return.
     """
-    annotations = apple_books.get_annotations_by_color(color)
+    annotations = apple_books.get_annotations_by_color(color, limit=limit)
     annotations_str = "\n".join([
         _format_annotation_with_book(annotation)
         for annotation in annotations
@@ -248,14 +284,15 @@ def get_highlights_by_color(color: str) -> TextContent:
 
 
 @mcp.tool()
-def search_highlighted_text(text: str) -> TextContent:
+def search_highlighted_text(text: str, limit: int = None) -> TextContent:
     """
     Search for annotations/highlights by highlighted text.
 
     Args:
         text: The text to search for.
+        limit: Maximum number of annotations to return.
     """
-    annotations = apple_books.search_annotation_by_highlighted_text(text)
+    annotations = apple_books.search_annotation_by_highlighted_text(text, limit=limit)
     annotations_str = "\n".join([
         _format_annotation_with_book(annotation)
         for annotation in annotations
@@ -267,14 +304,15 @@ def search_highlighted_text(text: str) -> TextContent:
 
 
 @mcp.tool()
-def search_notes(note: str) -> TextContent:
+def search_notes(note: str, limit: int = None) -> TextContent:
     """
     Search for annotations by note.
 
     Args:
         note: The note to search for.
+        limit: Maximum number of annotations to return.
     """
-    annotations = apple_books.search_annotation_by_note(note)
+    annotations = apple_books.search_annotation_by_note(note, limit=limit)
     annotations_str = "\n".join([
         f"{annotation.selected_text}\n"
         for annotation in annotations
@@ -286,14 +324,15 @@ def search_notes(note: str) -> TextContent:
 
 
 @mcp.tool()
-def full_text_search(text: str) -> TextContent:
+def full_text_search(text: str, limit: int = None) -> TextContent:
     """
     Search for annotations by any text that contains the given text.
 
     Args:
         text: The text to search for.
+        limit: Maximum number of annotations to return.
     """
-    annotations = apple_books.search_annotation_by_text(text)
+    annotations = apple_books.search_annotation_by_text(text, limit=limit)
     annotations_str = "\n".join([
         _format_annotation_with_book(annotation, include_chapter=True)
         for annotation in annotations
@@ -305,11 +344,14 @@ def full_text_search(text: str) -> TextContent:
 
 
 @mcp.tool()
-def recent_annotations() -> TextContent:
+def recent_annotations(limit: int = 10) -> TextContent:
     """
-    Get 10 most recent annotations.
+    Get most recent annotations.
+
+    Args:
+        limit: Maximum number of annotations to return. Defaults to 10.
     """
-    annotations = apple_books.list_annotations(limit=10, order_by="-creation_date")
+    annotations = apple_books.list_annotations(limit=limit, order_by="-creation_date")
     annotations_str = "\n".join([
         _format_annotation_with_book(annotation, include_chapter=True)
         for annotation in annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "click>=8.1.8",
     "fastmcp>=0.4.1",
-    "py-apple-books>=1.3.0",
+    "py-apple-books>=1.4.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.1.6"
+version = "0.2.0"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from apple_books_mcp.server import (
     list_all_collections, get_collection_books, describe_collection,
     list_all_books, get_book_annotations, describe_book,
+    search_books_by_title, search_collections_by_title,
     get_books_in_progress, get_finished_books, get_unstarted_books,
     get_recently_read_books,
     list_all_annotations, get_highlights_by_color, search_highlighted_text,
@@ -81,6 +82,8 @@ def mock_apple_books():
         mock.search_annotation_by_note.return_value = [anno]
         mock.search_annotation_by_text.return_value = [anno]
         mock.get_annotation_by_id.return_value = anno
+        mock.get_book_by_title.return_value = [book]
+        mock.get_collection_by_title.return_value = [MockCollection()]
         mock.get_books_in_progress.return_value = [book]
         mock.get_finished_books.return_value = [book]
         mock.get_unstarted_books.return_value = [book]
@@ -170,6 +173,18 @@ def test_recent_annotations_handles_missing_book(mock_apple_books):
 
     assert "Unknown Book" in result.text
     mock_apple_books.list_annotations.assert_called_once_with(limit=10, order_by="-creation_date")
+
+
+def test_search_books_by_title(mock_apple_books):
+    result = search_books_by_title("Book")
+    assert "Book 1" in result.text
+    mock_apple_books.get_book_by_title.assert_called_once_with("Book")
+
+
+def test_search_collections_by_title(mock_apple_books):
+    result = search_collections_by_title("Collection")
+    assert "Collection 1" in result.text
+    mock_apple_books.get_collection_by_title.assert_called_once_with("Collection")
 
 
 def test_get_books_in_progress(mock_apple_books):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 from apple_books_mcp.server import (
     list_all_collections, get_collection_books, describe_collection,
     list_all_books, get_book_annotations, describe_book,
+    get_books_in_progress, get_finished_books, get_unstarted_books,
+    get_recently_read_books,
     list_all_annotations, get_highlights_by_color, search_highlighted_text,
     search_notes, full_text_search, recent_annotations,
     describe_annotation
@@ -13,10 +15,18 @@ class MockBook:
     def __init__(self):
         self.id = "book1"
         self.title = "Book 1"
+        self.author = "Author 1"
         self.annotations = []
+        self.reading_progress = 45.0
+        self.is_finished = False
+        self.last_opened_date = None
+        self.duration = 3600
 
     def __str__(self):
         return "Book 1"
+
+    def format_progress_summary(self):
+        return "Progress: In Progress (45.0%) | Time Spent: 1.0h"
 
     @property
     def __dict__(self):
@@ -71,6 +81,10 @@ def mock_apple_books():
         mock.search_annotation_by_note.return_value = [anno]
         mock.search_annotation_by_text.return_value = [anno]
         mock.get_annotation_by_id.return_value = anno
+        mock.get_books_in_progress.return_value = [book]
+        mock.get_finished_books.return_value = [book]
+        mock.get_unstarted_books.return_value = [book]
+        mock.get_recently_read_books.return_value = [book]
 
         yield mock
 
@@ -156,6 +170,32 @@ def test_recent_annotations_handles_missing_book(mock_apple_books):
 
     assert "Unknown Book" in result.text
     mock_apple_books.list_annotations.assert_called_once_with(limit=10, order_by="-creation_date")
+
+
+def test_get_books_in_progress(mock_apple_books):
+    result = get_books_in_progress()
+    assert "Book 1" in result.text
+    assert "In Progress" in result.text
+    mock_apple_books.get_books_in_progress.assert_called_once()
+
+
+def test_get_finished_books(mock_apple_books):
+    result = get_finished_books()
+    assert "Book 1" in result.text
+    assert "Author 1" in result.text
+    mock_apple_books.get_finished_books.assert_called_once()
+
+
+def test_get_unstarted_books(mock_apple_books):
+    result = get_unstarted_books()
+    assert "Book 1" in result.text
+    mock_apple_books.get_unstarted_books.assert_called_once()
+
+
+def test_get_recently_read_books(mock_apple_books):
+    result = get_recently_read_books()
+    assert "Book 1" in result.text
+    mock_apple_books.get_recently_read_books.assert_called_once()
 
 
 def test_describe_annotation(mock_apple_books):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -95,7 +95,7 @@ def mock_apple_books():
 def test_list_all_collections(mock_apple_books):
     result = list_all_collections()
     assert "Collection 1" in result.text
-    mock_apple_books.list_collections.assert_called_once()
+    mock_apple_books.list_collections.assert_called_once_with(limit=None)
 
 
 def test_get_collection_books(mock_apple_books):
@@ -113,7 +113,7 @@ def test_describe_collection(mock_apple_books):
 def test_list_all_books(mock_apple_books):
     result = list_all_books()
     assert "Book 1" in result.text
-    mock_apple_books.list_books.assert_called_once()
+    mock_apple_books.list_books.assert_called_once_with(limit=None)
 
 
 def test_get_book_annotations(mock_apple_books):
@@ -131,31 +131,31 @@ def test_describe_book(mock_apple_books):
 def test_list_all_annotations(mock_apple_books):
     result = list_all_annotations()
     assert "Test text" in result.text
-    mock_apple_books.list_annotations.assert_called_once()
+    mock_apple_books.list_annotations.assert_called_once_with(limit=None)
 
 
 def test_get_highlights_by_color(mock_apple_books):
     result = get_highlights_by_color("yellow")
     assert "Test text" in result.text
-    mock_apple_books.get_annotations_by_color.assert_called_once_with("yellow")
+    mock_apple_books.get_annotations_by_color.assert_called_once_with("yellow", limit=None)
 
 
 def test_search_highlighted_text(mock_apple_books):
     result = search_highlighted_text("test")
     assert "Test text" in result.text
-    mock_apple_books.search_annotation_by_highlighted_text.assert_called_once_with("test")
+    mock_apple_books.search_annotation_by_highlighted_text.assert_called_once_with("test", limit=None)
 
 
 def test_search_notes(mock_apple_books):
     result = search_notes("note")
     assert "Test text" in result.text
-    mock_apple_books.search_annotation_by_note.assert_called_once_with("note")
+    mock_apple_books.search_annotation_by_note.assert_called_once_with("note", limit=None)
 
 
 def test_full_text_search(mock_apple_books):
     result = full_text_search("test")
     assert "Test text" in result.text
-    mock_apple_books.search_annotation_by_text.assert_called_once_with("test")
+    mock_apple_books.search_annotation_by_text.assert_called_once_with("test", limit=None)
 
 
 def test_recent_annotations(mock_apple_books):
@@ -191,26 +191,37 @@ def test_get_books_in_progress(mock_apple_books):
     result = get_books_in_progress()
     assert "Book 1" in result.text
     assert "In Progress" in result.text
-    mock_apple_books.get_books_in_progress.assert_called_once()
+    mock_apple_books.get_books_in_progress.assert_called_once_with(limit=None)
 
 
 def test_get_finished_books(mock_apple_books):
     result = get_finished_books()
     assert "Book 1" in result.text
     assert "Author 1" in result.text
-    mock_apple_books.get_finished_books.assert_called_once()
+    mock_apple_books.get_finished_books.assert_called_once_with(limit=None)
 
 
 def test_get_unstarted_books(mock_apple_books):
     result = get_unstarted_books()
     assert "Book 1" in result.text
-    mock_apple_books.get_unstarted_books.assert_called_once()
+    mock_apple_books.get_unstarted_books.assert_called_once_with(limit=None)
 
 
 def test_get_recently_read_books(mock_apple_books):
     result = get_recently_read_books()
     assert "Book 1" in result.text
-    mock_apple_books.get_recently_read_books.assert_called_once()
+    mock_apple_books.get_recently_read_books.assert_called_once_with(limit=10)
+
+
+def test_limit_parameter(mock_apple_books):
+    list_all_books(limit=5)
+    mock_apple_books.list_books.assert_called_once_with(limit=5)
+
+    recent_annotations(limit=3)
+    mock_apple_books.list_annotations.assert_called_with(limit=3, order_by="-creation_date")
+
+    get_books_in_progress(limit=2)
+    mock_apple_books.get_books_in_progress.assert_called_with(limit=2)
 
 
 def test_describe_annotation(mock_apple_books):

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.8" },
     { name = "fastmcp", specifier = ">=0.4.1" },
-    { name = "py-apple-books", specifier = ">=1.3.0" },
+    { name = "py-apple-books", specifier = ">=1.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -220,11 +220,11 @@ wheels = [
 
 [[package]]
 name = "py-apple-books"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/eb/ec171631b30eddbd0577adec088e92b992fb94cd8911b48c5ed9ec57f79d/py_apple_books-1.3.0.tar.gz", hash = "sha256:ec2d009b755e8dddc21882f277d13e7f61cae98c30ffe9b2b3c56dbd48a1d05e", size = 13325 }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/06/23c049b292b67dbdf0f4dd7e7476431d44d3e240076327dbc2a4023aa771/py_apple_books-1.4.0.tar.gz", hash = "sha256:5c20891834e3d3c6af71625b9ad98e20a90857f636eabe2790d0613d9e21968c", size = 13970 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/05/3ca0aa94114432e90c2fd333ca1914a3a3eeee442bb701a4568b9d44813b/py_apple_books-1.3.0-py3-none-any.whl", hash = "sha256:528d00ebcf668078c61a827145804dd8b219c56d1d3a6b636ad61f9d86fe9705", size = 15196 },
+    { url = "https://files.pythonhosted.org/packages/b6/95/a0d06336126f5e68a6d829ce47f51f49928d550598f99ff8d566096ed8bb/py_apple_books-1.4.0-py3-none-any.whl", hash = "sha256:d1e99b5cf9d6b8d3c020e7143b59f5ddab53381a0d45ae49231da6c7c896cf34", size = 15803 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add 4 reading status tools: `get_books_in_progress`, `get_finished_books`, `get_unstarted_books`, `get_recently_read_books`
- Add title search tools: `search_books_by_title`, `search_collections_by_title`
- Add optional `limit` parameter to all list and search tools
- Bump `py-apple-books` dependency to `>=1.4.0`
- Bump version to `0.2.0`
- Update README with organized tool tables

## Test plan
- [x] 21 unit tests passing (14 existing + 7 new)
- [x] End-to-end tested against real Apple Books library
- [x] Verified limit parameter works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)