### PR TITLE
Add library stats and date range filtering (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ And much more!
 | search_highlighted_text | Search highlights by text | text: str, limit?: int |
 | search_notes | Search annotations by note | note: str, limit?: int |
 | full_text_search | Search annotations by any text | text: str, limit?: int |
+| get_annotations_by_date_range | Get annotations within a date range | after?: YYYY-MM-DD, before?: YYYY-MM-DD, limit?: int |
+
+### Library Stats
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| get_library_stats | Get library summary with reading stats | None |
 
 ## Installation
 

--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 @click.command()

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -1,5 +1,6 @@
 import logging
 import json
+from datetime import datetime
 from mcp.types import (
     TextContent
 )
@@ -374,6 +375,32 @@ def describe_annotation(annotation_id: str) -> TextContent:
     return TextContent(
         type="text",
         text=f"{json.dumps(annotation.__dict__, default=str)}"
+    )
+
+
+@mcp.tool()
+def get_annotations_by_date_range(after: str = None, before: str = None, limit: int = None) -> TextContent:
+    """
+    Get annotations created within a date range.
+
+    Args:
+        after: Only include annotations created after this date (YYYY-MM-DD).
+        before: Only include annotations created before this date (YYYY-MM-DD).
+        limit: Maximum number of annotations to return.
+    """
+    after_dt = datetime.strptime(after, "%Y-%m-%d") if after else None
+    before_dt = datetime.strptime(before, "%Y-%m-%d") if before else None
+
+    annotations = apple_books.get_annotations_by_date_range(
+        after=after_dt, before=before_dt, limit=limit
+    )
+    annotations_str = "\n".join([
+        _format_annotation_with_book(annotation, include_chapter=True)
+        for annotation in annotations
+    ])
+    return TextContent(
+        type="text",
+        text=f"Annotations:\n{annotations_str}"
     )
 
 

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -377,6 +377,48 @@ def describe_annotation(annotation_id: str) -> TextContent:
     )
 
 
+# -- Library Stats Tools --
+@mcp.tool()
+def get_library_stats() -> TextContent:
+    """Get a summary of your Apple Books library with reading stats."""
+    books = list(apple_books.list_books())
+    annotations = list(apple_books.list_annotations())
+
+    total_books = len(books)
+    finished = sum(1 for b in books if getattr(b, "is_finished", False))
+    in_progress = sum(
+        1 for b in books
+        if (getattr(b, "reading_progress", 0) or 0) > 0
+        and not getattr(b, "is_finished", False)
+    )
+    unstarted = total_books - finished - in_progress
+
+    total_annotations = len(annotations)
+
+    # Count annotations per book
+    anno_counts = {}
+    for anno in annotations:
+        title = _get_book_title(anno)
+        anno_counts[title] = anno_counts.get(title, 0) + 1
+
+    top_annotated = sorted(anno_counts.items(), key=lambda x: x[1], reverse=True)[:5]
+    top_str = "\n".join([f"  {title}: {count}" for title, count in top_annotated])
+
+    stats = (
+        f"Total books: {total_books}\n"
+        f"Finished: {finished}\n"
+        f"In progress: {in_progress}\n"
+        f"Unstarted: {unstarted}\n"
+        f"Total annotations: {total_annotations}\n"
+        f"Most annotated books:\n{top_str}"
+    )
+
+    return TextContent(
+        type="text",
+        text=stats
+    )
+
+
 def serve():
     """Serve the Apple Books MCP server."""
     logger.info("--- Started Apple Books MCP server ---")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "click>=8.1.8",
     "fastmcp>=0.4.1",
-    "py-apple-books>=1.4.0",
+    "py-apple-books>=1.5.0",
 ]
 
 [tool.uv]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ from apple_books_mcp.server import (
     list_all_annotations, get_highlights_by_color, search_highlighted_text,
     search_notes, full_text_search, recent_annotations,
     describe_annotation,
+    get_annotations_by_date_range,
     get_library_stats
 )
 
@@ -89,6 +90,7 @@ def mock_apple_books():
         mock.get_finished_books.return_value = [book]
         mock.get_unstarted_books.return_value = [book]
         mock.get_recently_read_books.return_value = [book]
+        mock.get_annotations_by_date_range.return_value = [anno]
 
         yield mock
 
@@ -223,6 +225,24 @@ def test_limit_parameter(mock_apple_books):
 
     get_books_in_progress(limit=2)
     mock_apple_books.get_books_in_progress.assert_called_with(limit=2)
+
+
+def test_get_annotations_by_date_range(mock_apple_books):
+    from datetime import datetime
+    result = get_annotations_by_date_range(after="2025-01-01", before="2025-12-31")
+    assert "Test text" in result.text
+    mock_apple_books.get_annotations_by_date_range.assert_called_once_with(
+        after=datetime(2025, 1, 1), before=datetime(2025, 12, 31), limit=None
+    )
+
+
+def test_get_annotations_by_date_range_after_only(mock_apple_books):
+    from datetime import datetime
+    result = get_annotations_by_date_range(after="2025-06-01")
+    assert "Test text" in result.text
+    mock_apple_books.get_annotations_by_date_range.assert_called_once_with(
+        after=datetime(2025, 6, 1), before=None, limit=None
+    )
 
 
 def test_describe_annotation(mock_apple_books):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,7 +8,8 @@ from apple_books_mcp.server import (
     get_recently_read_books,
     list_all_annotations, get_highlights_by_color, search_highlighted_text,
     search_notes, full_text_search, recent_annotations,
-    describe_annotation
+    describe_annotation,
+    get_library_stats
 )
 
 
@@ -228,3 +229,13 @@ def test_describe_annotation(mock_apple_books):
     result = describe_annotation("anno1")
     assert "anno1" in result.text
     mock_apple_books.get_annotation_by_id.assert_called_once_with("anno1")
+
+
+def test_get_library_stats(mock_apple_books):
+    result = get_library_stats()
+    assert "Total books: 1" in result.text
+    assert "Total annotations: 1" in result.text
+    assert "Most annotated books:" in result.text
+    assert "Book 1" in result.text
+    mock_apple_books.list_books.assert_called_once()
+    mock_apple_books.list_annotations.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `get_library_stats` tool — aggregated reading and annotation summary (total books, finished/in-progress/unstarted, total annotations, top 5 most annotated books)
- Add `get_annotations_by_date_range` tool — filter annotations by creation date (YYYY-MM-DD format)
- Bump `py-apple-books` dependency to `>=1.5.0` (new `get_annotations_by_date_range` backend method)
- Bump version to `0.3.0`
- Update README

## Test plan
- [x] 24 unit tests passing
- [x] End-to-end tested against real Apple Books library
- [x] Backend `py-apple-books` v1.5.0 released ([v1.5.0](https://github.com/vgnshiyer/py-apple-books/releases/tag/v1.5.0))

🤖 Generated with [Claude Code](https://claude.com/claude-code)