### PR TITLE
Add MCP Registry manifest for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Apple Books MCP
 
+<!-- mcp-name: io.github.vgnshiyer/apple-books-mcp -->
+
 Model Context Protocol (MCP) server for Apple Books.
 
 ![](https://badge.mcpx.dev?type=server 'MCP Server')

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.vgnshiyer/apple-books-mcp",
+  "title": "Apple Books",
+  "description": "Access your Apple Books library, annotations, reading progress, and highlights through Claude",
+  "repository": {
+    "url": "https://github.com/vgnshiyer/apple-books-mcp",
+    "source": "github"
+  },
+  "version": "0.3.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "apple-books-mcp",
+      "version": "0.3.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `<!-- mcp-name: io.github.vgnshiyer/apple-books-mcp -->` to README for PyPI ownership verification
- Add `server.json` manifest for MCP Registry publishing

## Next steps
After merging, create a v0.3.1 release so the updated README is live on PyPI, then publish to the MCP Registry with `mcp-publisher publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)