### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Build and push Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT ["apple-books-mcp"]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ After installing, you can run the server using:
 python -m apple_books_mcp
 ```
 
+### Using Docker
+
+```bash
+docker run -v ~/Library/Containers/com.apple.iBooksX/Data/Documents:/root/Library/Containers/com.apple.iBooksX/Data/Documents:ro ghcr.io/vgnshiyer/apple-books-mcp:latest
+```
+
 ## Configuration
 
 ### Claude Desktop Setup
@@ -124,9 +130,25 @@ python -m apple_books_mcp
 }
 ```
 
+#### Using Docker
+
+```json
+{
+    "mcpServers": {
+        "apple-books-mcp": {
+            "command": "docker",
+            "args": [
+                "run", "-i", "--rm",
+                "-v", "~/Library/Containers/com.apple.iBooksX/Data/Documents:/root/Library/Containers/com.apple.iBooksX/Data/Documents:ro",
+                "ghcr.io/vgnshiyer/apple-books-mcp:latest"
+            ]
+        }
+    }
+}
+```
+
 ## Upcoming Features
 
-- [ ] add docker support
 - [ ] add resources support
 - [ ] edit collections support
 - [ ] edit highlights support


### PR DESCRIPTION
## Summary
- Add `Dockerfile` for containerized deployment
- Add CI workflow to build and push Docker image to `ghcr.io/vgnshiyer/apple-books-mcp` on release
- Update README with Docker installation and Claude Desktop configuration
- Users mount their Apple Books database directory as a read-only volume

## Claude Desktop config
```json
{
    "mcpServers": {
        "apple-books-mcp": {
            "command": "docker",
            "args": [
                "run", "-i", "--rm",
                "-v", "~/Library/Containers/com.apple.iBooksX/Data/Documents:/root/Library/Containers/com.apple.iBooksX/Data/Documents:ro",
                "ghcr.io/vgnshiyer/apple-books-mcp:latest"
            ]
        }
    }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)