### PR TITLE
Bump to 0.3.3 — pick up date fix from py-apple-books 1.5.1

### DIFF
--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.3.1"
+__version__ = "0.3.3"
 
 
 @click.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.3.1"
+version = "0.3.3"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "click>=8.1.8",
     "fastmcp>=0.4.1",
-    "py-apple-books>=1.5.0",
+    "py-apple-books>=1.5.1",
 ]
 
 [tool.uv]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vgnshiyer/apple-books-mcp",
     "source": "github"
   },
-  "version": "0.3.1",
+  "version": "0.3.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-books-mcp",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Bump `py-apple-books` dependency to `>=1.5.1`
- Bump version to 0.3.3

py-apple-books 1.5.1 fixes the Apple epoch date conversion bug. Book and annotation dates now render correctly (previously off by ~31 years — e.g. 2026 annotations showed as 1994).

🤖 Generated with [Claude Code](https://claude.com/claude-code)