### PR TITLE
Add get_books_by_genre tool (v0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ And much more!
 | describe_book | Get details of a particular book | book_id: str |
 | get_book_annotations | Get all annotations for a book | book_id: str |
 | search_books_by_title | Search for books by title | title: str |
+| get_books_by_genre | Get books by genre (substring match) | genre: str, limit?: int |
 
 ### Reading Status
 

--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 
 
 @click.command()

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -152,6 +152,26 @@ def search_books_by_title(title: str) -> TextContent:
 
 
 @mcp.tool()
+def get_books_by_genre(genre: str, limit: int = None) -> TextContent:
+    """
+    Get books whose genre matches the given string (substring match).
+
+    Args:
+        genre: The genre to search for (e.g. "Romance", "Philosophy").
+        limit: Maximum number of books to return.
+    """
+    books = apple_books.get_books_by_genre(genre, limit=limit)
+    books_str = "\n".join([
+        f"{getattr(book, 'title', 'Unknown')} by {getattr(book, 'author', 'Unknown')} ({getattr(book, 'genre', None)})"
+        for book in books
+    ])
+    return TextContent(
+        type="text",
+        text=f"Books:\n{books_str}"
+    )
+
+
+@mcp.tool()
 def search_collections_by_title(title: str) -> TextContent:
     """
     Search for collections by title.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.3.3"
+version = "0.4.0"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "click>=8.1.8",
     "fastmcp>=0.4.1",
-    "py-apple-books>=1.5.1",
+    "py-apple-books>=1.6.0",
 ]
 
 [tool.uv]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vgnshiyer/apple-books-mcp",
     "source": "github"
   },
-  "version": "0.3.3",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-books-mcp",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from apple_books_mcp.server import (
     list_all_collections, get_collection_books, describe_collection,
     list_all_books, get_book_annotations, describe_book,
-    search_books_by_title, search_collections_by_title,
+    search_books_by_title, search_collections_by_title, get_books_by_genre,
     get_books_in_progress, get_finished_books, get_unstarted_books,
     get_recently_read_books,
     list_all_annotations, get_highlights_by_color, search_highlighted_text,
@@ -24,6 +24,7 @@ class MockBook:
         self.is_finished = False
         self.last_opened_date = None
         self.duration = 3600
+        self.genre = "Romance"
 
     def __str__(self):
         return "Book 1"
@@ -91,6 +92,7 @@ def mock_apple_books():
         mock.get_unstarted_books.return_value = [book]
         mock.get_recently_read_books.return_value = [book]
         mock.get_annotations_by_date_range.return_value = [anno]
+        mock.get_books_by_genre.return_value = [book]
 
         yield mock
 
@@ -182,6 +184,13 @@ def test_search_books_by_title(mock_apple_books):
     result = search_books_by_title("Book")
     assert "Book 1" in result.text
     mock_apple_books.get_book_by_title.assert_called_once_with("Book")
+
+
+def test_get_books_by_genre(mock_apple_books):
+    result = get_books_by_genre("Romance")
+    assert "Book 1" in result.text
+    assert "Romance" in result.text
+    mock_apple_books.get_books_by_genre.assert_called_once_with("Romance", limit=None)
 
 
 def test_search_collections_by_title(mock_apple_books):


### PR DESCRIPTION
## Summary
- Add `get_books_by_genre(genre, limit)` tool with substring matching
- Requires `py-apple-books>=1.6.0` (new backend method)
- Bump to 0.4.0

## Example
- `get_books_by_genre("Romance")` matches both "Romance" and "Contemporary Romance"
- `get_books_by_genre("Philosophy")` returns philosophy books

## Test plan
- [x] 25 unit tests passing
- [x] End-to-end tested against real library

🤖 Generated with [Claude Code](https://claude.com/claude-code)