### PR TITLE
Add timestamps to annotation output (v0.4.1)

### DIFF
--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 @click.command()

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -28,12 +28,14 @@ def _get_book_title(annotation) -> str:
 def _format_annotation_with_book(annotation, include_chapter: bool = False) -> str:
     annotation_text = getattr(annotation, "selected_text", None)
     book_title = _get_book_title(annotation)
+    created = getattr(annotation, "creation_date", None)
+    timestamp = created.strftime("%Y-%m-%dT%H:%M:%S") if created else "unknown"
 
     if include_chapter:
         chapter = getattr(annotation, "chapter", None)
-        return f"{annotation_text} from {book_title}, Chapter: {chapter}\n"
+        return f"[{timestamp}] {annotation_text} from {book_title}, Chapter: {chapter}\n"
 
-    return f"{annotation_text} from {book_title}\n"
+    return f"[{timestamp}] {annotation_text} from {book_title}\n"
 
 
 # -- Collections Tools --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vgnshiyer/apple-books-mcp",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-books-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 from unittest.mock import patch
 from apple_books_mcp.server import (
     list_all_collections, get_collection_books, describe_collection,
@@ -45,8 +46,8 @@ class MockAnnotation:
         self.book = MockBook()
         self.chapter = "Chapter 1"
         self.location = "Page 1"
-        self.creation_date = "2023-01-01"
-        self.modification_date = "2023-01-02"
+        self.creation_date = datetime(2026, 4, 16, 14, 23, 45)
+        self.modification_date = datetime(2026, 4, 16, 14, 24, 0)
 
     def __str__(self):
         return "Highlight: Test text"
@@ -234,6 +235,12 @@ def test_limit_parameter(mock_apple_books):
 
     get_books_in_progress(limit=2)
     mock_apple_books.get_books_in_progress.assert_called_with(limit=2)
+
+
+def test_annotation_output_includes_timestamp(mock_apple_books):
+    """Timestamps are required for Claude to cluster annotations into sessions."""
+    result = recent_annotations()
+    assert "2026-04-16T14:23:45" in result.text
 
 
 def test_get_annotations_by_date_range(mock_apple_books):


### PR DESCRIPTION
## Summary

Prepends ISO timestamp to each annotation returned by search and date-range tools:

Before: \`Kin selection accounts for... from The Selfish Gene, Chapter: None\`
After:  \`[2026-04-16T14:23:45] Kin selection accounts for... from The Selfish Gene, Chapter: None\`

## Why

Enables Claude to cluster annotations into reading sessions without a dedicated endpoint. Asking *"Show me my reading sessions from this week"* now returns enough context for Claude to group highlights by book + time proximity.

## Scope

Only \`_format_annotation_with_book\` is updated — affects tools that use it: \`get_highlights_by_color\`, \`search_highlighted_text\`, \`full_text_search\`, \`recent_annotations\`, \`get_annotations_by_date_range\`.

## Test plan
- [x] 26 tests passing (1 new test verifies timestamp in output)
- [x] End-to-end verified against real library

🤖 Generated with [Claude Code](https://claude.com/claude-code)