### PR TITLE
Add currently-reading resource (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ And much more!
 |------|-------------|------------|
 | get_library_stats | Get library summary with reading stats | None |
 
+## Available Resources
+
+Attachable data objects accessible from Claude Desktop's resource picker.
+
+| Resource | URI | Description |
+|----------|-----|-------------|
+| Currently Reading | `apple-books://currently-reading` | The book you're reading right now — most recently opened in-progress book, with its metadata and recent annotations. Attach to any conversation to focus Claude on your current read. |
+
 ## Available Prompts
 
 One-click workflows, accessible from Claude Desktop's prompt picker.

--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 
 @click.command()

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -484,6 +484,55 @@ def get_library_stats() -> TextContent:
     )
 
 
+# -- Resources --
+@mcp.resource(
+    "apple-books://currently-reading",
+    name="Currently Reading",
+    description="The book you're actively reading right now — the most recently opened in-progress book, with its metadata and recent annotations. Attach this to any conversation to give Claude your current reading context.",
+    mime_type="text/plain",
+)
+def currently_reading_resource() -> str:
+    """The most recently opened in-progress book, with its annotations."""
+    books = list(apple_books.get_books_in_progress(limit=1, order_by="-last_opened_date"))
+    if not books:
+        return "No book currently in progress."
+
+    book = books[0]
+    author = getattr(book, "author", None) or "Unknown Author"
+    title = getattr(book, "title", None) or "Unknown Title"
+    description = getattr(book, "description", None) or ""
+    progress_summary = book.format_progress_summary()
+
+    header = [
+        f"Currently Reading: {title} by {author}",
+        progress_summary,
+    ]
+    if description:
+        header.append(f"\nAbout: {description}")
+
+    annotations = sorted(
+        getattr(book, "annotations", []) or [],
+        key=lambda a: getattr(a, "creation_date", None) or "",
+        reverse=True,
+    )
+    # Cap to most recent 50 to keep the attached context manageable
+    annotations = annotations[:50]
+
+    if not annotations:
+        return "\n".join(header) + "\n\nNo annotations in this book yet."
+
+    lines = header + [f"\nRecent annotations ({len(annotations)} shown):\n"]
+    for anno in annotations:
+        created = getattr(anno, "creation_date", None)
+        timestamp = created.strftime("%Y-%m-%dT%H:%M:%S") if created else "unknown"
+        chapter = getattr(anno, "chapter", None)
+        body = _annotation_body(anno)
+        chapter_tag = f" (Chapter: {chapter})" if chapter else ""
+        lines.append(f"[{timestamp}]{chapter_tag} {body}")
+
+    return "\n".join(lines)
+
+
 # -- Prompts --
 @mcp.prompt()
 def weekly_digest(days: int = 7) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vgnshiyer/apple-books-mcp",
     "source": "github"
   },
-  "version": "0.5.0",
+  "version": "0.6.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-books-mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -280,6 +280,30 @@ def test_describe_annotation(mock_apple_books):
     mock_apple_books.get_annotation_by_id.assert_called_once_with("anno1")
 
 
+def test_currently_reading_resource_registered():
+    """The currently-reading resource is available for attachment."""
+    import asyncio
+    from apple_books_mcp.server import mcp
+
+    resources = asyncio.run(mcp.list_resources())
+    uris = {str(r.uri) for r in resources}
+    assert "apple-books://currently-reading" in uris
+
+
+def test_currently_reading_resource_content(mock_apple_books):
+    """Reading the resource returns the most recent in-progress book with its annotations."""
+    import asyncio
+    from apple_books_mcp.server import mcp
+
+    result = asyncio.run(mcp.read_resource("apple-books://currently-reading"))
+    content = result[0].content if hasattr(result[0], "content") else str(result[0])
+    assert "Currently Reading: Book 1 by Author 1" in content
+    assert "In Progress" in content
+    # Annotations should be included
+    assert "Test text" in content
+    mock_apple_books.get_books_in_progress.assert_called_with(limit=1, order_by="-last_opened_date")
+
+
 def test_prompts_registered():
     """Verify all 5 prompts are exposed via MCP."""
     import asyncio


### PR DESCRIPTION
## Summary

Adds the first MCP resource: \`apple-books://currently-reading\`.

Returns the single book you're actively reading right now — the most recently opened in-progress book — along with its metadata, progress, and up to 50 most recent annotations.

## UX

Appears in Claude Desktop's resource/attach picker. Attach it once at the start of a conversation and Claude has your current reading context without any tool call roundtrip. Perfect for:
- Discussing what you're reading in real time
- "Explain this passage" while reading
- Session-long conversations about one book

## Test plan
- [x] 30 tests passing (2 new tests for resource registration + content)
- [x] End-to-end verified against real library — returned *The Selfish Gene* with 50 recent highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)