### PR TITLE
Chapter content access + reshape annotation tools (v0.7.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# MCP Registry auth (downloaded by mcp-publisher login)
+.mcpregistry_github_token
+.mcpregistry_registry_token

--- a/README.md
+++ b/README.md
@@ -12,13 +12,10 @@ Model Context Protocol (MCP) server for Apple Books.
 
 ## At a glance
 
-* Ask Claude to summarize your recent highlights
-* Ask Claude what books you're currently reading and your progress
-* Ask Claude to pick up where you left off — it can see the chapter you're on *and* its text
-* Ask Claude to find a book by title
-* Ask Claude to organize books in your library by genre
-* Ask Claude to recommend similar books based on your reading history
-* Ask Claude to compare notes from different books read on the same subject
+* **Pick up where you left off** — Claude sees the chapter you're on *and* its text, plus recent highlights in the book.
+* **Expand on any highlight** — get the surrounding paragraph explained in context, with the exact anchor you marked shown in `«...»`.
+* **Revisit a book** — pull your highlights, cluster them by theme, and quote you back to yourself.
+* **Reflect on your reading** — patterns across books, recurring ideas in your highlights, what you're actually drawn to.
 
 https://github.com/user-attachments/assets/77a5a29b-bfd7-4275-a4af-8d6c51a4527e
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Model Context Protocol (MCP) server for Apple Books.
 
 * Ask Claude to summarize your recent highlights
 * Ask Claude what books you're currently reading and your progress
+* Ask Claude to pick up where you left off — it can see the chapter you're on *and* its text
 * Ask Claude to find a book by title
 * Ask Claude to organize books in your library by genre
 * Ask Claude to recommend similar books based on your reading history
@@ -39,8 +40,8 @@ And much more!
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | list_all_books | List all books | limit?: int |
-| describe_book | Get details of a particular book | book_id: str |
-| get_book_annotations | Get all annotations for a book | book_id: str |
+| describe_book | Get details of a particular book (metadata, progress, annotation count, description) | book_id: str |
+| list_annotations | Get all annotations for a book (id + text + chapter per row, chapter-ordered) | book_id: int, limit?: int |
 | search_books_by_title | Search for books by title | title: str |
 | get_books_by_genre | Get books by genre (substring match) | genre: str, limit?: int |
 
@@ -57,14 +58,14 @@ And much more!
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| list_all_annotations | List all annotations | limit?: int |
-| recent_annotations | Get most recent annotations | limit?: int (default: 10) |
-| describe_annotation | Get details of an annotation | annotation_id: str |
-| get_highlights_by_color | Get all highlights by color | color: str, limit?: int |
-| search_highlighted_text | Search highlights by text | text: str, limit?: int |
-| search_notes | Search annotations by note | note: str, limit?: int |
-| full_text_search | Search annotations by any text | text: str, limit?: int |
-| get_annotations_by_date_range | Get annotations within a date range | after?: YYYY-MM-DD, before?: YYYY-MM-DD, limit?: int |
+| list_all_annotations | Browse every annotation grouped by book, newest first | limit?: int |
+| recent_annotations | Get most recent annotations (flat, with date + book per row) | limit?: int (default: 10) |
+| describe_annotation | Get full details of a single annotation | annotation_id: str |
+| get_annotation_context | Text window around a highlight (the paragraph it's in), with the highlight marked `«...»` | annotation_id: int, chars_before?: int (default: 500), chars_after?: int (default: 500) |
+| get_highlights_by_color | Highlights of a particular color, grouped by book | color: str, limit?: int |
+| search_notes | Search user notes (shows highlight + note inline) | note: str, limit?: int |
+| search_annotations | Search across highlights + notes + surrounding text | text: str, limit?: int |
+| get_annotations_by_date_range | Annotations within a date range (flat, with date + book per row) | after?: YYYY-MM-DD, before?: YYYY-MM-DD, limit?: int |
 
 ### Library Stats
 
@@ -72,13 +73,23 @@ And much more!
 |------|-------------|------------|
 | get_library_stats | Get library summary with reading stats | None |
 
+### Book Content
+
+Only works for non-DRM EPUBs (imported books, Project Gutenberg, Standard Ebooks, etc.). Apple Books Store purchases are FairPlay-protected and return a clear error. iCloud-only books return a "not downloaded" hint.
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| list_book_chapters | Table of contents for a book (chapter titles, order, nesting) | book_id: int |
+| get_chapter_content | Plain-text content of a chapter, with optional `offset` + `max_chars` slicing | book_id: int, chapter_id: str, offset?: int, max_chars?: int |
+| get_current_reading_position | The chapter the user last left off reading (via Apple Books' auto-bookmark CFI) | book_id: int |
+
 ## Available Resources
 
 Attachable data objects accessible from Claude Desktop's resource picker.
 
 | Resource | URI | Description |
 |----------|-----|-------------|
-| Currently Reading | `apple-books://currently-reading` | The book you're reading right now — most recently opened in-progress book, with its metadata and recent annotations. Attach to any conversation to focus Claude on your current read. |
+| Currently Reading | `apple-books://currently-reading` | The book you're reading right now — most recently opened in-progress book, with metadata, **the chapter you left off on plus a preview of its text** (for non-DRM EPUBs), and recent annotations. Attach to any conversation to focus Claude on your current read. |
 
 ## Available Prompts
 
@@ -170,7 +181,8 @@ docker run -v ~/Library/Containers/com.apple.iBooksX/Data/Documents:/root/Librar
 
 ## Upcoming Features
 
-- [ ] book content access for non-DRM EPUBs
+- [ ] PDF content access (currently EPUB-only)
+- [ ] fuller annotation context via CFI → paragraph resolution
 
 ## Contribution
 

--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 
 @click.command()

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -1,57 +1,33 @@
 import logging
-import json
+import re
 from datetime import datetime
 from mcp.types import (
     TextContent
 )
 from mcp.server.fastmcp import FastMCP
 from py_apple_books import PyAppleBooks
+from py_apple_books.exceptions import (
+    AppleBooksError,
+    BookNotDownloadedError,
+    DRMProtectedError,
+)
+
+from apple_books_mcp.utils import (
+    _annotation_body,
+    _build_current_reading_section,
+    _chapter_title_map,
+    _format_book_with_progress,
+    _format_flat_with_timestamp,
+    _format_grouped_by_book,
+    _format_lean_row,
+    _format_note_row,
+    _get_book_title,
+)
 
 logger = logging.getLogger("apple-books-mcp")
 
 mcp = FastMCP("apple-books")
 apple_books = PyAppleBooks()
-
-
-def _format_book_with_progress(book) -> str:
-    author = getattr(book, "author", None) or "Unknown Author"
-    title = getattr(book, "title", None) or "Unknown Title"
-    progress = book.format_progress_summary()
-    return f"{title} by {author}\n{progress}"
-
-
-def _get_book_title(annotation) -> str:
-    book = getattr(annotation, "book", None)
-    return getattr(book, "title", None) or "Unknown Book"
-
-
-def _annotation_body(annotation) -> str:
-    """Pick the most informative text for the annotation.
-
-    `representative_text` contains the surrounding sentence/paragraph; `selected_text`
-    is what the user specifically highlighted. They're often identical, but when they
-    differ the fuller context is usually more useful to the model — while the specific
-    highlight still carries signal about what the reader zeroed in on.
-    """
-    rep = (getattr(annotation, "representative_text", None) or "").strip()
-    sel = (getattr(annotation, "selected_text", None) or "").strip()
-
-    if rep and sel and rep != sel and len(rep) > len(sel) + 20:
-        return f"{rep} ↳ highlighted: \"{sel}\""
-    return rep or sel
-
-
-def _format_annotation_with_book(annotation, include_chapter: bool = False) -> str:
-    annotation_text = _annotation_body(annotation)
-    book_title = _get_book_title(annotation)
-    created = getattr(annotation, "creation_date", None)
-    timestamp = created.strftime("%Y-%m-%dT%H:%M:%S") if created else "unknown"
-
-    if include_chapter:
-        chapter = getattr(annotation, "chapter", None)
-        return f"[{timestamp}] {annotation_text} from {book_title}, Chapter: {chapter}\n"
-
-    return f"[{timestamp}] {annotation_text} from {book_title}\n"
 
 
 # -- Collections Tools --
@@ -90,15 +66,55 @@ def get_collection_books(collection_id: str) -> TextContent:
 @mcp.tool()
 def describe_collection(collection_id: str) -> TextContent:
     """
-    Get details of a particular collection.
+    Describe a specific collection in detail — title, details text,
+    and the books contained in it.
 
     Args:
         collection_id: The ID of the collection to get details for.
     """
-    collection = apple_books.get_collection_by_id(collection_id)
+    try:
+        collection = apple_books.get_collection_by_id(collection_id)
+    except IndexError:
+        return TextContent(
+            type="text", text=f"No collection found with id {collection_id}."
+        )
+
+    title = getattr(collection, "title", None) or "Untitled Collection"
+    lines = [title, f"  Collection id: {collection.id}"]
+
+    details = (getattr(collection, "details", None) or "").strip()
+    if details:
+        lines.append(f"  Details: {details}")
+
+    try:
+        books = list(collection.books)
+    except Exception:
+        books = []
+
+    lines.append(f"  Books: {len(books)}")
+    if books:
+        lines.append("")
+        for book in books:
+            btitle = getattr(book, "title", None) or "Unknown Title"
+            bauthor = getattr(book, "author", None) or "Unknown Author"
+            lines.append(f"  - [{book.id}] {btitle} by {bauthor}")
+
+    return TextContent(type="text", text="\n".join(lines))
+
+
+@mcp.tool()
+def search_collections_by_title(title: str) -> TextContent:
+    """
+    Search for collections by title.
+
+    Args:
+        title: The title to search for.
+    """
+    collections = apple_books.get_collection_by_title(title)
+    collections_str = "\n".join([f"{str(collection)}\n" for collection in collections])
     return TextContent(
         type="text",
-        text=f"{json.dumps(collection.__dict__, default=str)}"
+        text=f"Collections:\n{collections_str}"
     )
 
 
@@ -120,37 +136,62 @@ def list_all_books(limit: int = None) -> TextContent:
 
 
 @mcp.tool()
-def get_book_annotations(book_id: str) -> TextContent:
-    """
-    Get all annotations for a particular book.
-
-    Args:
-        book_id: The ID of the book to get annotations for.
-    """
-    book = apple_books.get_book_by_id(book_id)
-    annotations_str = "\n".join([
-        f"{annotation.selected_text}\n"
-        for annotation in book.annotations
-    ])
-    return TextContent(
-        type="text",
-        text=f"Annotations:\n{annotations_str}"
-    )
-
-
-@mcp.tool()
 def describe_book(book_id: str) -> TextContent:
     """
-    Get details of a particular book.
+    Describe a specific book in detail — metadata (title, author, genre,
+    page count), reading status (progress, last opened, finished date),
+    and annotation count.
 
     Args:
         book_id: The ID of the book to get.
     """
-    book = apple_books.get_book_by_id(book_id)
-    return TextContent(
-        type="text",
-        text=f"{json.dumps(book.__dict__, default=str)}"
-    )
+    try:
+        book = apple_books.get_book_by_id(book_id)
+    except IndexError:
+        return TextContent(type="text", text=f"No book found with id {book_id}.")
+
+    title = getattr(book, "title", None) or "Unknown Title"
+    author = getattr(book, "author", None) or "Unknown Author"
+
+    lines = [f"{title} by {author}", f"  Book id: {book.id}"]
+
+    genre = getattr(book, "genre", None)
+    if genre:
+        lines.append(f"  Genre:    {genre}")
+
+    page_count = getattr(book, "page_count", None)
+    if page_count:
+        lines.append(f"  Pages:    {page_count}")
+
+    # Reading status — reuse the same compact summary used elsewhere.
+    lines.append(f"  {book.format_progress_summary()}")
+
+    finished_date = getattr(book, "finished_date", None)
+    if finished_date:
+        lines.append(f"  Finished: {finished_date.strftime('%Y-%m-%d')}")
+
+    purchased_date = getattr(book, "purchased_date", None)
+    if purchased_date:
+        lines.append(f"  Added:    {purchased_date.strftime('%Y-%m-%d')}")
+
+    rating = getattr(book, "rating", None)
+    if rating:
+        lines.append(f"  Rating:   {rating}/5")
+
+    # Annotation count — useful signal for "should I bother listing them?"
+    try:
+        anno_count = len(list(book.annotations))
+    except Exception:
+        anno_count = 0
+    if anno_count:
+        lines.append(f"  Annotations: {anno_count}")
+
+    description = (getattr(book, "description", None) or "").strip()
+    if description:
+        lines.append("")
+        lines.append(f"About: {description}")
+
+    return TextContent(type="text", text="\n".join(lines))
 
 
 @mcp.tool()
@@ -186,22 +227,6 @@ def get_books_by_genre(genre: str, limit: int = None) -> TextContent:
     return TextContent(
         type="text",
         text=f"Books:\n{books_str}"
-    )
-
-
-@mcp.tool()
-def search_collections_by_title(title: str) -> TextContent:
-    """
-    Search for collections by title.
-
-    Args:
-        title: The title to search for.
-    """
-    collections = apple_books.get_collection_by_title(title)
-    collections_str = "\n".join([f"{str(collection)}\n" for collection in collections])
-    return TextContent(
-        type="text",
-        text=f"Collections:\n{collections_str}"
     )
 
 
@@ -286,144 +311,381 @@ def get_recently_read_books(limit: int = 10) -> TextContent:
 @mcp.tool()
 def list_all_annotations(limit: int = None) -> TextContent:
     """
-    List all my annotations in my Apple Books library.
+    Browse all your annotations grouped by book, most recent first.
+    Each row is ``[annotation_id] <text> — <chapter title> (ch=<id>)``.
+    For the surrounding passage of a specific highlight, follow up
+    with ``get_annotation_context(annotation_id)``. For the full
+    chapter, pass the emitted ``ch=<id>`` to ``get_chapter_content``.
+
+    Chapter resolution uses Apple Books' CFI hints; books that can't
+    be opened (DRM, iCloud-only) still appear, just without the
+    chapter suffix.
 
     Args:
+        limit: Maximum number of annotations to return. Applied before
+            grouping; defaults to unlimited, which may produce a very
+            long list on heavily-annotated libraries.
+    """
+    # Default to newest-first — old annotations are often from books
+    # the user has since removed from their library (orphan rows), and
+    # the library's DB stores in Z_PK order, so the oldest entries
+    # surface first. Sorting by creation date descending puts current
+    # reading activity at the top of the output.
+    annotations = list(
+        apple_books.list_annotations(limit=limit, order_by="-creation_date")
+    )
+    if not annotations:
+        return TextContent(type="text", text="No annotations.")
+
+    # Group by book. Orphans (asset_id → no book in the library) get a
+    # dedicated tail section.
+    from collections import defaultdict
+    by_book: dict = defaultdict(list)
+    orphans: list = []
+    for anno in annotations:
+        book = getattr(anno, "book", None)
+        if book is None:
+            orphans.append(anno)
+        else:
+            by_book[book.id].append((anno, book))
+
+    # Resolve chapter titles per book exactly once.
+    chapter_maps = {book_id: _chapter_title_map(apple_books, book_id) for book_id in by_book}
+
+    lines: list = []
+    for book_id, pairs in by_book.items():
+        book = pairs[0][1]
+        author = getattr(book, "author", None) or "Unknown Author"
+        lines.append(f"\n{book.title} ({author}):")
+        ch_map = chapter_maps[book_id]
+        for anno, _ in pairs:
+            lines.append(f"  {_format_lean_row(anno, ch_map)}")
+
+    if orphans:
+        lines.append("\nUnassigned (book no longer in library):")
+        for anno in orphans:
+            lines.append(f"  {_format_lean_row(anno, {})}")
+
+    return TextContent(type="text", text="\n".join(lines).lstrip())
+
+
+@mcp.tool()
+def list_annotations(book_id: int, limit: int = None) -> TextContent:
+    """
+    List annotations within a specific book. Returns minimal rows —
+    ``[annotation_id] <chapter title>`` — since the caller already
+    scoped the query by book id.
+
+    Ordered by chapter position in the book (reading order), then by
+    creation date for ties. Unresolvable chapters (sub-sections not
+    in the ToC, DRM books) show ``—``.
+
+    Args:
+        book_id: The book's numeric ID.
         limit: Maximum number of annotations to return.
     """
-    annotations = apple_books.list_annotations(limit=limit)
-    annotations_str = "\n".join([
-        f"ID: {annotation.id} - Selected Text: {annotation.selected_text}\n"
-        for annotation in annotations
-    ])
-    return TextContent(
-        type="text",
-        text=f"Annotations:\n{annotations_str}"
-    )
+    try:
+        book = apple_books.get_book_by_id(book_id)
+    except IndexError:
+        return TextContent(type="text", text=f"No book found with id {book_id}.")
+
+    annotations = list(book.annotations)
+    if not annotations:
+        return TextContent(
+            type="text", text=f"No annotations in '{book.title}'."
+        )
+
+    ch_map = _chapter_title_map(apple_books, book.id)
+    # Also precompute chapter order for a reading-order sort.
+    try:
+        content = apple_books.get_book_content(book.id)
+        chapter_order = {c.id: c.order for c in content.list_chapters()}
+    except (BookNotDownloadedError, DRMProtectedError, AppleBooksError):
+        chapter_order = {}
+
+    def _sort_key(a):
+        cid = a.location.chapter_id if a.location else None
+        order = chapter_order.get(cid, float("inf")) if cid else float("inf")
+        created = getattr(a, "creation_date", None)
+        return (order, created or datetime.min)
+
+    annotations.sort(key=_sort_key)
+    if limit:
+        annotations = annotations[:limit]
+
+    lines = [_format_lean_row(a, ch_map) for a in annotations]
+    return TextContent(type="text", text="\n".join(lines))
 
 
 @mcp.tool()
 def get_highlights_by_color(color: str, limit: int = None) -> TextContent:
     """
-    Get all annotations/highlights by color.
+    Browse highlights of a particular color, grouped by book.
+
+    Output is one row per highlight: ``[id] text — chapter``. The
+    book's name is shown once in the header, with a count of matching
+    highlights.
 
     Args:
-        color: The color of the annotations/highlights.
+        color: ``yellow``, ``green``, ``blue``, ``pink``, or ``purple``.
         limit: Maximum number of annotations to return.
     """
     annotations = apple_books.get_annotations_by_color(color, limit=limit)
-    annotations_str = "\n".join([
-        _format_annotation_with_book(annotation)
-        for annotation in annotations
-    ])
-    return TextContent(
-        type="text",
-        text=f"Annotations:\n{annotations_str}"
+
+    def color_header(book, annos):
+        author = getattr(book, "author", None) or "Unknown Author"
+        count = len(annos)
+        plural = "" if count == 1 else "s"
+        return f"{book.title} ({author}) — {count} {color.lower()} highlight{plural}:"
+
+    text = _format_grouped_by_book(
+        apple_books,
+        annotations,
+        empty_message=f"No {color} highlights.",
+        book_header=color_header,
     )
-
-
-@mcp.tool()
-def search_highlighted_text(text: str, limit: int = None) -> TextContent:
-    """
-    Search for annotations/highlights by highlighted text.
-
-    Args:
-        text: The text to search for.
-        limit: Maximum number of annotations to return.
-    """
-    annotations = apple_books.search_annotation_by_highlighted_text(text, limit=limit)
-    annotations_str = "\n".join([
-        _format_annotation_with_book(annotation)
-        for annotation in annotations
-    ])
-    return TextContent(
-        type="text",
-        text=f"Annotations:\n{annotations_str}"
-    )
+    return TextContent(type="text", text=text)
 
 
 @mcp.tool()
 def search_notes(note: str, limit: int = None) -> TextContent:
     """
-    Search for annotations by note.
+    Search user notes (not highlights) by substring, grouped by book.
+    Output shows the highlighted passage on the primary row and the
+    matching note on a second line prefixed with ``↳ note:``.
 
     Args:
-        note: The note to search for.
+        note: Substring to find inside note bodies.
         limit: Maximum number of annotations to return.
     """
     annotations = apple_books.search_annotation_by_note(note, limit=limit)
-    annotations_str = "\n".join([
-        f"{annotation.selected_text}\n"
-        for annotation in annotations
-    ])
     return TextContent(
         type="text",
-        text=f"Annotations:\n{annotations_str}"
+        text=_format_grouped_by_book(
+            apple_books,
+            annotations,
+            empty_message=f"No notes matched {note!r}.",
+            row_formatter=_format_note_row,
+        ),
     )
 
 
 @mcp.tool()
-def full_text_search(text: str, limit: int = None) -> TextContent:
+def search_annotations(text: str, limit: int = None) -> TextContent:
     """
-    Search for annotations by any text that contains the given text.
+    Search across every annotation field — selected (highlighted) text,
+    the surrounding paragraph, and the user's note body. Grouped by
+    book. Use ``search_notes`` when you only want to find your own
+    written notes.
 
     Args:
-        text: The text to search for.
+        text: Substring to match anywhere in an annotation.
         limit: Maximum number of annotations to return.
     """
     annotations = apple_books.search_annotation_by_text(text, limit=limit)
-    annotations_str = "\n".join([
-        _format_annotation_with_book(annotation, include_chapter=True)
-        for annotation in annotations
-    ])
     return TextContent(
         type="text",
-        text=f"Annotations:\n{annotations_str}"
+        text=_format_grouped_by_book(
+            apple_books, annotations, empty_message=f"No annotations matched {text!r}."
+        ),
     )
 
 
 @mcp.tool()
 def recent_annotations(limit: int = 10) -> TextContent:
     """
-    Get most recent annotations.
+    Most recent annotations, newest first. Flat rows with the creation
+    date and book name inline so Claude can see chronology across
+    books at a glance.
+
+    Row format::
+
+        YYYY-MM-DD [id] text — chapter · Book Title
 
     Args:
         limit: Maximum number of annotations to return. Defaults to 10.
     """
     annotations = apple_books.list_annotations(limit=limit, order_by="-creation_date")
-    annotations_str = "\n".join([
-        _format_annotation_with_book(annotation, include_chapter=True)
-        for annotation in annotations
-    ])
     return TextContent(
         type="text",
-        text=f"Annotations:\n{annotations_str}"
+        text=_format_flat_with_timestamp(
+            apple_books, annotations, empty_message="No annotations."
+        ),
     )
 
 
 @mcp.tool()
 def describe_annotation(annotation_id: str) -> TextContent:
     """
-    Get details of a particular annotation.
+    Describe a specific annotation in detail — its text, note, book,
+    chapter (with chapter_id for hand-off to ``get_chapter_content``),
+    color, creation date, and raw CFI. Use this when you have an
+    annotation id from one of the listing tools and want the full
+    picture. For just the surrounding paragraph, call
+    ``get_annotation_context`` instead.
 
     Args:
-        annotation_id: The ID of the annotation to get.
+        annotation_id: The annotation's numeric ID.
     """
-    annotation = apple_books.get_annotation_by_id(annotation_id)
-    return TextContent(
-        type="text",
-        text=f"{json.dumps(annotation.__dict__, default=str)}"
-    )
+    try:
+        anno = apple_books.get_annotation_by_id(annotation_id)
+    except IndexError:
+        return TextContent(
+            type="text", text=f"No annotation found with id {annotation_id}."
+        )
+
+    book = getattr(anno, "book", None)
+    book_title = getattr(book, "title", None) or "(book no longer in library)"
+    book_author = getattr(book, "author", None) or "?"
+
+    # Resolve chapter title via the CFI, same as the listing tools.
+    chapter_title = ""
+    chapter_id = None
+    if book and anno.location and anno.location.chapter_id:
+        chapter_id = anno.location.chapter_id
+        ch_map = _chapter_title_map(apple_books, book.id)
+        chapter_title = ch_map.get(chapter_id, "")
+
+    created = getattr(anno, "creation_date", None)
+    created_str = created.strftime("%Y-%m-%d %H:%M") if created else "unknown"
+
+    lines = [
+        f"Annotation {anno.id}",
+        f"  Book:     {book_title} ({book_author})",
+    ]
+    # Show both the human title and the id so Claude can pass chapter_id
+    # directly to get_chapter_content without rescanning the ToC.
+    if chapter_title and chapter_id:
+        lines.append(f"  Chapter:  {chapter_title} (ch={chapter_id})")
+    elif chapter_id:
+        lines.append(f"  Chapter:  (ch={chapter_id})")
+    lines.append(f"  Created:  {created_str}")
+    if getattr(anno, "color", None):
+        lines.append(f"  Color:    {anno.color}")
+
+    selected = (getattr(anno, "selected_text", None) or "").strip()
+    rep = (getattr(anno, "representative_text", None) or "").strip()
+    note = (getattr(anno, "note", None) or "").strip()
+
+    if selected:
+        lines.append("")
+        lines.append(f'  Highlighted: "{selected}"')
+    if rep and rep != selected:
+        lines.append(f'  In context:  "{rep}"')
+    if note:
+        lines.append(f"  Note:        {note}")
+
+    cfi = str(anno.location) if anno.location else ""
+    if cfi:
+        lines.append("")
+        lines.append(f"  CFI: {cfi}")
+
+    return TextContent(type="text", text="\n".join(lines))
+
+
+@mcp.tool()
+def get_annotation_context(
+    annotation_id: int,
+    chars_before: int = 500,
+    chars_after: int = 500,
+) -> TextContent:
+    """
+    Return a text window around a single annotation — the passage
+    immediately before and after the user's highlight, snapped to word
+    boundaries. The highlighted text itself is wrapped in guillemets
+    (``«...»``) inside the output so Claude can see the exact anchor.
+
+    Use this to explain or expand on a specific highlight without
+    fetching the whole chapter. For a full-chapter view, follow up with
+    ``get_chapter_content``.
+
+    Only works for non-DRM EPUBs that have been downloaded to this Mac.
+    DRM-protected Apple Books Store purchases, iCloud-only books, and
+    annotations whose CFI has no chapter hint all degrade to a clear
+    "no context available" message.
+
+    Args:
+        annotation_id: The annotation's numeric ID (from any of the
+            listing tools).
+        chars_before: Characters of context before the highlight.
+            Default 500.
+        chars_after: Characters of context after the highlight.
+            Default 500.
+    """
+    try:
+        anno = apple_books.get_annotation_by_id(annotation_id)
+    except IndexError:
+        return TextContent(
+            type="text",
+            text=f"No annotation found with id {annotation_id}.",
+        )
+
+    try:
+        window = apple_books.get_annotation_surrounding_text(
+            annotation_id,
+            chars_before=chars_before,
+            chars_after=chars_after,
+        )
+    except (BookNotDownloadedError, DRMProtectedError, AppleBooksError) as e:
+        return TextContent(
+            type="text", text=f"Could not read annotation context: {e}"
+        )
+
+    if not window:
+        # Backend returns "" in several degraded cases — surface a
+        # reason so Claude (or the user) knows whether to retry with a
+        # different annotation or move on.
+        if not anno.location or not anno.location.chapter_id:
+            reason = (
+                "this annotation has no CFI chapter hint "
+                "(likely an older or iCloud-only highlight)."
+            )
+        elif getattr(anno, "book", None) is None:
+            reason = "the book is no longer in the library."
+        else:
+            reason = (
+                "the book isn't downloaded locally, is DRM-protected, "
+                "or the highlight's anchor text can't be located."
+            )
+        return TextContent(
+            type="text", text=f"No surrounding context available: {reason}"
+        )
+
+    # Wrap the highlight with guillemets so Claude can see exactly which
+    # span the user marked. Match with flexible whitespace — Apple
+    # Books stores ``selected_text`` with the EPUB's original line
+    # breaks intact, but our HTML→text extraction normalizes them to
+    # spaces, so a literal ``in`` check fails for most multi-line
+    # highlights. First occurrence only: if the anchor text repeats in
+    # the window, subsequent occurrences stay unmarked to avoid
+    # implying they're all highlighted.
+    selected = (getattr(anno, "selected_text", None) or "").strip()
+    tokens = selected.split() if selected else []
+    if tokens:
+        pattern = r"\s+".join(re.escape(t) for t in tokens)
+        m = re.search(pattern, window)
+        if m:
+            matched = m.group(0)
+            window = window.replace(matched, f"«{matched}»", 1)
+
+    return TextContent(type="text", text=window)
 
 
 @mcp.tool()
 def get_annotations_by_date_range(after: str = None, before: str = None, limit: int = None) -> TextContent:
     """
-    Get annotations created within a date range.
+    Annotations created within a date range. Flat rows with the
+    creation date and book name inline.
+
+    Row format::
+
+        YYYY-MM-DD [id] text — chapter · Book Title
 
     Args:
-        after: Only include annotations created after this date (YYYY-MM-DD).
-        before: Only include annotations created before this date (YYYY-MM-DD).
+        after: Only include annotations created on or after this date
+            (YYYY-MM-DD).
+        before: Only include annotations created on or before this
+            date (YYYY-MM-DD).
         limit: Maximum number of annotations to return.
     """
     after_dt = datetime.strptime(after, "%Y-%m-%d") if after else None
@@ -432,13 +694,212 @@ def get_annotations_by_date_range(after: str = None, before: str = None, limit: 
     annotations = apple_books.get_annotations_by_date_range(
         after=after_dt, before=before_dt, limit=limit
     )
-    annotations_str = "\n".join([
-        _format_annotation_with_book(annotation, include_chapter=True)
-        for annotation in annotations
-    ])
     return TextContent(
         type="text",
-        text=f"Annotations:\n{annotations_str}"
+        text=_format_flat_with_timestamp(
+            apple_books, annotations, empty_message="No annotations in that range."
+        ),
+    )
+
+
+# -- Content Tools --
+@mcp.tool()
+def list_book_chapters(book_id: int) -> TextContent:
+    """
+    List the table of contents for a book — chapter titles, order, and
+    nesting depth. Only works for non-DRM EPUBs that have been downloaded
+    to this Mac.
+
+    Args:
+        book_id: The book's numeric ID (from ``list_all_books`` or similar).
+    """
+    try:
+        content = apple_books.get_book_content(book_id)
+    except BookNotDownloadedError as e:
+        return TextContent(type="text", text=f"Book not available: {e}")
+    except DRMProtectedError as e:
+        return TextContent(type="text", text=f"Book is DRM-protected: {e}")
+    except AppleBooksError as e:
+        return TextContent(type="text", text=f"Could not open book: {e}")
+    except IndexError:
+        return TextContent(
+            type="text", text=f"No book found with id {book_id}."
+        )
+
+    try:
+        chapters = content.list_chapters()
+    except AppleBooksError as e:
+        return TextContent(type="text", text=f"Could not list chapters: {e}")
+
+    if not chapters:
+        return TextContent(type="text", text="No chapters found for this book.")
+
+    lines = [f"Chapters ({len(chapters)} total):"]
+    for ch in chapters:
+        indent = "  " * ch.depth
+        lines.append(f"  [{ch.order:>3}] {indent}{ch.title}  (id={ch.id})")
+    return TextContent(type="text", text="\n".join(lines))
+
+
+@mcp.tool()
+def get_chapter_content(
+    book_id: int,
+    chapter_id: str,
+    offset: int = 0,
+    max_chars: int = None,
+) -> TextContent:
+    """
+    Return the plain-text content of a specific chapter, with optional
+    slicing so long chapters don't consume the whole context window.
+
+    ``chapter_id`` should come from a prior ``list_book_chapters`` call
+    (or from the ``(ch=...)`` suffix printed on annotation listing rows).
+    It accepts either the ``Chapter.id`` value or the 1-based chapter
+    order rendered as a string (e.g. ``"5"``). Only works for non-DRM
+    EPUBs that have been downloaded to this Mac.
+
+    Pagination is opt-in — the tool never truncates on its own. If you
+    don't pass ``max_chars``, you get the whole chapter, however long.
+    To sample a long chapter, pass ``max_chars`` (and optionally
+    ``offset`` for continuation).
+
+    Every response ends with an explicit footer showing the exact
+    ``offset`` / ``end`` / ``total`` character counts, so you can
+    decide whether to re-call with a new ``offset`` without guessing.
+    Example footers::
+
+        (full chapter returned: 4,872 chars.)
+        …(returned chars 0–8000 of 24,311 [8000 chars]. Call again with
+          offset=8000 to continue; 16,311 chars remaining.)
+        (returned chars 16000–24311 of 24311 [8311 chars]. End of chapter.)
+
+    Args:
+        book_id: The book's numeric ID.
+        chapter_id: The chapter identifier or 1-based position.
+        offset: Character offset to start from (0 = start of chapter).
+            Useful for paginating through a long chapter without
+            re-reading the part you've already seen.
+        max_chars: Maximum characters to return in this call. Omit (or
+            pass ``None``) to get the whole chapter from ``offset``
+            onward. Set to something like ``8000`` when you want to
+            sample a long chapter without blowing up the context.
+    """
+    try:
+        content = apple_books.get_book_content(book_id)
+    except BookNotDownloadedError as e:
+        return TextContent(type="text", text=f"Book not available: {e}")
+    except DRMProtectedError as e:
+        return TextContent(type="text", text=f"Book is DRM-protected: {e}")
+    except AppleBooksError as e:
+        return TextContent(type="text", text=f"Could not open book: {e}")
+    except IndexError:
+        return TextContent(
+            type="text", text=f"No book found with id {book_id}."
+        )
+
+    try:
+        text = content.get_chapter(chapter_id)
+    except AppleBooksError as e:
+        return TextContent(type="text", text=f"Could not read chapter: {e}")
+
+    if not text.strip():
+        return TextContent(
+            type="text",
+            text="(This chapter has no extractable text — likely an image-only page.)",
+        )
+
+    total_chars = len(text)
+
+    # Clamp offset to the chapter's length — an out-of-range offset
+    # should fail soft with a clear message instead of silently
+    # returning "".
+    if offset < 0:
+        offset = 0
+    if offset >= total_chars:
+        return TextContent(
+            type="text",
+            text=(
+                f"Offset {offset} is past the end of the chapter "
+                f"(total {total_chars} chars). Pass a smaller offset."
+            ),
+        )
+
+    if max_chars is None:
+        sliced = text[offset:]
+        end = total_chars
+    else:
+        if max_chars <= 0:
+            return TextContent(
+                type="text", text="max_chars must be a positive integer."
+            )
+        end = min(offset + max_chars, total_chars)
+        sliced = text[offset:end]
+
+    # Always append a pagination footer so Claude sees exactly what it
+    # just received and whether there's more. The tool does not auto-
+    # paginate — if Claude wants the rest, it calls again with the
+    # suggested offset.
+    returned = end - offset
+    remaining = total_chars - end
+    if remaining > 0:
+        footer = (
+            f"…(returned chars {offset}–{end} of {total_chars} "
+            f"[{returned} chars]. Call again with offset={end} to "
+            f"continue; {remaining} chars remaining.)"
+        )
+    elif offset == 0 and end == total_chars:
+        footer = f"(full chapter returned: {total_chars} chars.)"
+    else:
+        footer = (
+            f"(returned chars {offset}–{end} of {total_chars} "
+            f"[{returned} chars]. End of chapter.)"
+        )
+
+    return TextContent(type="text", text=f"{sliced}\n\n{footer}")
+
+
+@mcp.tool()
+def get_current_reading_position(book_id: int) -> TextContent:
+    """
+    Return the chapter the user last left off reading, based on Apple Books'
+    auto-tracked reading position bookmark. Useful when the caller wants to
+    focus on a specific book rather than the global ``currently-reading``
+    resource.
+
+    Returns the chapter metadata only (title, order, href). For the chapter
+    text, follow up with ``get_chapter_content``. Only works for non-DRM
+    EPUBs that have been downloaded to this Mac.
+
+    Args:
+        book_id: The book's numeric ID.
+    """
+    try:
+        chapter = apple_books.get_current_reading_chapter(book_id)
+    except BookNotDownloadedError as e:
+        return TextContent(type="text", text=f"Book not available: {e}")
+    except DRMProtectedError as e:
+        return TextContent(type="text", text=f"Book is DRM-protected: {e}")
+    except AppleBooksError as e:
+        return TextContent(type="text", text=f"Could not resolve position: {e}")
+    except IndexError:
+        return TextContent(
+            type="text", text=f"No book found with id {book_id}."
+        )
+
+    if chapter is None:
+        return TextContent(
+            type="text",
+            text="No reading position recorded for this book yet.",
+        )
+
+    return TextContent(
+        type="text",
+        text=(
+            f"Current chapter: [{chapter.order}] {chapter.title}\n"
+            f"Chapter id (for get_chapter_content): {chapter.id}\n"
+            f"Depth in ToC: {chapter.depth}\n"
+            f"File: {chapter.href}"
+        ),
     )
 
 
@@ -488,11 +949,12 @@ def get_library_stats() -> TextContent:
 @mcp.resource(
     "apple-books://currently-reading",
     name="Currently Reading",
-    description="The book you're actively reading right now — the most recently opened in-progress book, with its metadata and recent annotations. Attach this to any conversation to give Claude your current reading context.",
+    description="The book you're actively reading right now — the most recently opened in-progress book, with its metadata, the chapter you left off on (plus a preview of its text when the book isn't DRM-protected), and recent annotations. Attach this to any conversation to give Claude your current reading context.",
     mime_type="text/plain",
 )
 def currently_reading_resource() -> str:
-    """The most recently opened in-progress book, with its annotations."""
+    """The most recently opened in-progress book, plus where the user left
+    off (chapter + text preview) and their recent annotations."""
     books = list(apple_books.get_books_in_progress(limit=1, order_by="-last_opened_date"))
     if not books:
         return "No book currently in progress."
@@ -503,34 +965,48 @@ def currently_reading_resource() -> str:
     description = getattr(book, "description", None) or ""
     progress_summary = book.format_progress_summary()
 
-    header = [
+    sections: list[str] = [
         f"Currently Reading: {title} by {author}",
         progress_summary,
     ]
     if description:
-        header.append(f"\nAbout: {description}")
+        sections.append(f"\nAbout: {description}")
 
+    # --- current chapter + preview (new in v0.7.0) ------------------------
+    #
+    # Apple Books auto-tracks the reader's position as a zero-width
+    # bookmark annotation with an EPUB CFI. When the book is readable
+    # (non-DRM, locally downloaded), surface the chapter the user left
+    # off on plus a bounded text preview so Claude can engage with
+    # what the user is actually in the middle of.
+    reading_section = _build_current_reading_section(apple_books, book)
+    if reading_section:
+        sections.append(reading_section)
+
+    # --- recent annotations -----------------------------------------------
     annotations = sorted(
         getattr(book, "annotations", []) or [],
         key=lambda a: getattr(a, "creation_date", None) or "",
         reverse=True,
     )
-    # Cap to most recent 50 to keep the attached context manageable
+    # Cap to most recent 50 to keep the attached context manageable.
     annotations = annotations[:50]
 
     if not annotations:
-        return "\n".join(header) + "\n\nNo annotations in this book yet."
+        sections.append("\nNo annotations in this book yet.")
+        return "\n".join(sections)
 
-    lines = header + [f"\nRecent annotations ({len(annotations)} shown):\n"]
+    ann_lines = [f"\nRecent annotations ({len(annotations)} shown):\n"]
     for anno in annotations:
         created = getattr(anno, "creation_date", None)
         timestamp = created.strftime("%Y-%m-%dT%H:%M:%S") if created else "unknown"
         chapter = getattr(anno, "chapter", None)
         body = _annotation_body(anno)
         chapter_tag = f" (Chapter: {chapter})" if chapter else ""
-        lines.append(f"[{timestamp}]{chapter_tag} {body}")
+        ann_lines.append(f"[{timestamp}]{chapter_tag} {body}")
 
-    return "\n".join(lines)
+    sections.append("\n".join(ann_lines))
+    return "\n".join(sections)
 
 
 # -- Prompts --
@@ -592,7 +1068,8 @@ def revisit_book(book_title: str) -> str:
     return (
         f"I want to revisit my notes on \"{book_title}\".\n\n"
         f"1. Call `search_books_by_title` with \"{book_title}\" to find it.\n"
-        "2. Call `get_book_annotations` with the book's ID to pull every highlight.\n"
+        "2. Call `list_annotations` with the book's ID to pull every highlight "
+        "(returns each as id + text + chapter).\n"
         "3. Group related highlights together by theme or argument.\n"
         "4. Surface the 2-3 most interesting threads — what was I fixated on in this book?\n"
         "5. If I wrote any notes (not just highlights), call those out — they usually "

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -745,11 +745,11 @@ def get_chapter_content(
     book_id: int,
     chapter_id: str,
     offset: int = 0,
-    max_chars: int = None,
+    max_chars: int = 10000,
 ) -> TextContent:
     """
-    Return the plain-text content of a specific chapter, with optional
-    slicing so long chapters don't consume the whole context window.
+    Return the plain-text content of a specific chapter, paginated by
+    default so a long chapter can't blow up the context window.
 
     ``chapter_id`` should come from a prior ``list_book_chapters`` call
     (or from the ``(ch=...)`` suffix printed on annotation listing rows).
@@ -757,10 +757,13 @@ def get_chapter_content(
     order rendered as a string (e.g. ``"5"``). Only works for non-DRM
     EPUBs that have been downloaded to this Mac.
 
-    Pagination is opt-in — the tool never truncates on its own. If you
-    don't pass ``max_chars``, you get the whole chapter, however long.
-    To sample a long chapter, pass ``max_chars`` (and optionally
-    ``offset`` for continuation).
+    Default ``max_chars=10000`` (~2500 words) covers most typical
+    chapters in a single call; chapters under this cap return as
+    ``(full chapter returned: N chars.)``. Longer chapters return the
+    first slice with a pagination footer naming the exact ``offset``
+    to pass next. Raise ``max_chars`` if you're confident the chapter
+    is short, or pass ``max_chars=None`` to get everything in one
+    call (use sparingly — some chapters run to 50k+ chars).
 
     Every response ends with an explicit footer showing the exact
     ``offset`` / ``end`` / ``total`` character counts, so you can
@@ -768,9 +771,9 @@ def get_chapter_content(
     Example footers::
 
         (full chapter returned: 4,872 chars.)
-        …(returned chars 0–8000 of 24,311 [8000 chars]. Call again with
-          offset=8000 to continue; 16,311 chars remaining.)
-        (returned chars 16000–24311 of 24311 [8311 chars]. End of chapter.)
+        …(returned chars 0–10000 of 24,311 [10000 chars]. Call again with
+          offset=10000 to continue; 14,311 chars remaining.)
+        (returned chars 20000–24311 of 24311 [4311 chars]. End of chapter.)
 
     Args:
         book_id: The book's numeric ID.
@@ -778,10 +781,10 @@ def get_chapter_content(
         offset: Character offset to start from (0 = start of chapter).
             Useful for paginating through a long chapter without
             re-reading the part you've already seen.
-        max_chars: Maximum characters to return in this call. Omit (or
-            pass ``None``) to get the whole chapter from ``offset``
-            onward. Set to something like ``8000`` when you want to
-            sample a long chapter without blowing up the context.
+        max_chars: Maximum characters to return in this call. Defaults
+            to 10000 — enough for ~2500 words of reasoning without
+            eating the context. Pass a higher value when you need more
+            in one shot, or ``None`` to return the entire chapter.
     """
     try:
         content = apple_books.get_book_content(book_id)
@@ -809,9 +812,12 @@ def get_chapter_content(
 
     total_chars = len(text)
 
-    # Clamp offset to the chapter's length — an out-of-range offset
-    # should fail soft with a clear message instead of silently
-    # returning "".
+    # Validate inputs before slicing. ``max_chars=None`` is the
+    # documented opt-out for pagination — treated as "read to end".
+    if max_chars is not None and max_chars <= 0:
+        return TextContent(
+            type="text", text="max_chars must be a positive integer."
+        )
     if offset < 0:
         offset = 0
     if offset >= total_chars:
@@ -823,21 +829,12 @@ def get_chapter_content(
             ),
         )
 
-    if max_chars is None:
-        sliced = text[offset:]
-        end = total_chars
-    else:
-        if max_chars <= 0:
-            return TextContent(
-                type="text", text="max_chars must be a positive integer."
-            )
-        end = min(offset + max_chars, total_chars)
-        sliced = text[offset:end]
+    # Slice. Either cap at max_chars or read through to the end.
+    end = total_chars if max_chars is None else min(offset + max_chars, total_chars)
+    sliced = text[offset:end]
 
-    # Always append a pagination footer so Claude sees exactly what it
-    # just received and whether there's more. The tool does not auto-
-    # paginate — if Claude wants the rest, it calls again with the
-    # suggested offset.
+    # Footer always shows the exact bounds so Claude can paginate
+    # (or stop) without guessing what it just received.
     returned = end - offset
     remaining = total_chars - end
     if remaining > 0:

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -13,7 +13,6 @@ from py_apple_books.exceptions import (
 )
 
 from apple_books_mcp.utils import (
-    _annotation_body,
     _build_current_reading_section,
     _chapter_title_map,
     _format_book_with_progress,
@@ -949,12 +948,24 @@ def get_library_stats() -> TextContent:
 @mcp.resource(
     "apple-books://currently-reading",
     name="Currently Reading",
-    description="The book you're actively reading right now — the most recently opened in-progress book, with its metadata, the chapter you left off on (plus a preview of its text when the book isn't DRM-protected), and recent annotations. Attach this to any conversation to give Claude your current reading context.",
+    description=(
+        "A lightweight pointer to the book you're actively reading right "
+        "now — title, author, ids, progress, and the chapter you last "
+        "left off on. Attach this to any conversation to give Claude your "
+        "reading context without pulling chapter text or annotations; "
+        "Claude can fetch those on demand via get_chapter_content, "
+        "list_annotations, and get_annotation_context."
+    ),
     mime_type="text/plain",
 )
 def currently_reading_resource() -> str:
-    """The most recently opened in-progress book, plus where the user left
-    off (chapter + text preview) and their recent annotations."""
+    """Lean resource: metadata + ids + chapter pointer.
+
+    By design this does NOT embed chapter text or annotations — pulling
+    them eagerly inflated attached context by ~10–15k chars per use.
+    The resource now weighs in at ~300 chars and hands Claude the
+    book_id + chapter_id it needs to fetch richer content on demand.
+    """
     books = list(apple_books.get_books_in_progress(limit=1, order_by="-last_opened_date"))
     if not books:
         return "No book currently in progress."
@@ -962,50 +973,32 @@ def currently_reading_resource() -> str:
     book = books[0]
     author = getattr(book, "author", None) or "Unknown Author"
     title = getattr(book, "title", None) or "Unknown Title"
-    description = getattr(book, "description", None) or ""
-    progress_summary = book.format_progress_summary()
 
     sections: list[str] = [
         f"Currently Reading: {title} by {author}",
-        progress_summary,
+        f"  Book id: {book.id}",
+        f"  {book.format_progress_summary()}",
     ]
-    if description:
-        sections.append(f"\nAbout: {description}")
 
-    # --- current chapter + preview (new in v0.7.0) ------------------------
-    #
-    # Apple Books auto-tracks the reader's position as a zero-width
-    # bookmark annotation with an EPUB CFI. When the book is readable
-    # (non-DRM, locally downloaded), surface the chapter the user left
-    # off on plus a bounded text preview so Claude can engage with
-    # what the user is actually in the middle of.
+    # Current chapter pointer — metadata only, no text.
     reading_section = _build_current_reading_section(apple_books, book)
     if reading_section:
         sections.append(reading_section)
 
-    # --- recent annotations -----------------------------------------------
-    annotations = sorted(
-        getattr(book, "annotations", []) or [],
-        key=lambda a: getattr(a, "creation_date", None) or "",
-        reverse=True,
-    )
-    # Cap to most recent 50 to keep the attached context manageable.
-    annotations = annotations[:50]
+    # Annotation count only — keeps the resource cheap. Claude can call
+    # list_annotations(book_id) when it actually wants to browse them.
+    try:
+        anno_count = len(list(book.annotations))
+    except Exception:
+        anno_count = 0
+    if anno_count:
+        sections.append(
+            f"\nHighlights in this book: {anno_count}  "
+            f"(use list_annotations({book.id}) to browse)"
+        )
+    else:
+        sections.append("\nHighlights in this book: 0")
 
-    if not annotations:
-        sections.append("\nNo annotations in this book yet.")
-        return "\n".join(sections)
-
-    ann_lines = [f"\nRecent annotations ({len(annotations)} shown):\n"]
-    for anno in annotations:
-        created = getattr(anno, "creation_date", None)
-        timestamp = created.strftime("%Y-%m-%dT%H:%M:%S") if created else "unknown"
-        chapter = getattr(anno, "chapter", None)
-        body = _annotation_body(anno)
-        chapter_tag = f" (Chapter: {chapter})" if chapter else ""
-        ann_lines.append(f"[{timestamp}]{chapter_tag} {body}")
-
-    sections.append("\n".join(ann_lines))
     return "\n".join(sections)
 
 

--- a/apple_books_mcp/utils.py
+++ b/apple_books_mcp/utils.py
@@ -31,12 +31,6 @@ logger = logging.getLogger("apple-books-mcp")
 # Constants
 # --------------------------------------------------------------------------
 
-# Approximate cap on how much chapter text to include in the
-# currently-reading resource. Picked so a typical book chapter fits
-# without blowing up the attached context — ~2000 words / 8000 chars is
-# plenty for Claude to engage with the passage.
-_CURRENT_CHAPTER_CHAR_CAP = 8000
-
 # Max characters shown for a single annotation in list-style outputs.
 # Typical highlights are 1–3 sentences (50–200 chars); this cap keeps
 # each row a single readable line without truncating most.
@@ -58,23 +52,6 @@ def _format_book_with_progress(book) -> str:
 def _get_book_title(annotation) -> str:
     book = getattr(annotation, "book", None)
     return getattr(book, "title", None) or "Unknown Book"
-
-
-def _annotation_body(annotation) -> str:
-    """Pick the most informative text for the annotation.
-
-    ``representative_text`` contains the surrounding sentence/paragraph;
-    ``selected_text`` is what the user specifically highlighted. They're
-    often identical, but when they differ the fuller context is usually
-    more useful to the model — while the specific highlight still
-    carries signal about what the reader zeroed in on.
-    """
-    rep = (getattr(annotation, "representative_text", None) or "").strip()
-    sel = (getattr(annotation, "selected_text", None) or "").strip()
-
-    if rep and sel and rep != sel and len(rep) > len(sel) + 20:
-        return f"{rep} ↳ highlighted: \"{sel}\""
-    return rep or sel
 
 
 # ``_format_annotation_with_book`` (legacy) was dropped in v0.7.0 — it
@@ -315,12 +292,15 @@ def _chapter_title_map(api: "PyAppleBooks", book_id: int) -> dict:
 
 
 def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
-    """Return a human-readable 'you left off on…' block, or '' if we
-    can't read the book's content (DRM, not downloaded, no bookmark).
+    """Return a compact 'you left off on…' metadata block, or '' if we
+    can't resolve the user's reading position (DRM, not downloaded, no
+    bookmark).
 
-    Intentionally soft-failing: a missing chapter shouldn't break the
-    currently_reading resource — the annotations section is still
-    valuable even when content access is unavailable.
+    Lean-by-design: emits only the chapter's title, order, and id —
+    never the chapter text. If Claude wants the text, it calls
+    ``get_chapter_content(book_id, chapter_id)`` on demand. This keeps
+    the attached resource small so it doesn't dominate the context
+    window.
     """
     try:
         chapter = api.get_current_reading_chapter(book.id)
@@ -333,7 +313,7 @@ def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
         return (
             "\nCurrent chapter: not readable — this is a DRM-protected "
             "Apple Books Store purchase; only imported EPUBs expose their "
-            "chapter text."
+            "chapter metadata."
         )
     except AppleBooksError as e:
         logger.warning("current reading chapter unavailable: %s", e)
@@ -345,28 +325,13 @@ def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
     try:
         content = api.get_book_content(book.id)
         total_chapters = len(content.list_chapters())
-        full_text = content.get_chapter(chapter.id)
     except AppleBooksError as e:
-        logger.warning("chapter content unavailable: %s", e)
-        return (
-            f"\nCurrent chapter: [{chapter.order}] {chapter.title}\n"
-            f"(chapter text unavailable)"
-        )
+        logger.warning("chapter count unavailable: %s", e)
+        total_chapters = None
 
-    header = f"\nCurrent chapter: [{chapter.order}/{total_chapters}] {chapter.title}"
-
-    # Some EPUB sections are image-only (cover pages, part dividers that are
-    # rendered as a JPG). Extraction returns an empty string in that case —
-    # skip the "--- chapter text ---" block rather than emit an empty one.
-    if not full_text.strip():
-        return f"{header}\n(This chapter has no extractable text, likely an image-only page.)"
-
-    truncated = full_text[:_CURRENT_CHAPTER_CHAR_CAP]
-    suffix = (
-        f"\n\n…(truncated after {_CURRENT_CHAPTER_CHAR_CAP:,} chars; "
-        f"chapter continues for {len(full_text) - _CURRENT_CHAPTER_CHAR_CAP:,} more)"
-        if len(full_text) > _CURRENT_CHAPTER_CHAR_CAP
-        else ""
+    position = f"[{chapter.order}/{total_chapters}]" if total_chapters else f"[{chapter.order}]"
+    return (
+        f"\nCurrent chapter: {position} {chapter.title}"
+        f"\n  Chapter id: {chapter.id}  "
+        f"(pass to get_chapter_content for the text)"
     )
-
-    return f"{header}\n\n--- chapter text ---\n{truncated}{suffix}"

--- a/apple_books_mcp/utils.py
+++ b/apple_books_mcp/utils.py
@@ -301,7 +301,20 @@ def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
     ``get_chapter_content(book_id, chapter_id)`` on demand. This keeps
     the attached resource small so it doesn't dominate the context
     window.
+
+    Two-tier resolution:
+
+    1. Preferred: :meth:`PyAppleBooks.get_current_reading_chapter`
+       gives a full :class:`Chapter` entry when the CFI's chapter_id
+       matches a ToC item.
+    2. Fallback: many EPUBs store the reading-position CFI against a
+       manifest item id that the ToC doesn't list (sub-section, or a
+       re-numbered spine entry). The chapter is still fetchable via
+       :meth:`get_chapter_content` — we just don't have a human
+       title. Peek at the raw Location and emit the id alone so
+       Claude can still hand it off.
     """
+    # Tier 1: try the clean ToC-resolved chapter first.
     try:
         chapter = api.get_current_reading_chapter(book.id)
     except BookNotDownloadedError:
@@ -319,19 +332,40 @@ def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
         logger.warning("current reading chapter unavailable: %s", e)
         return ""
 
-    if chapter is None:
+    if chapter is not None:
+        try:
+            content = api.get_book_content(book.id)
+            total_chapters = len(content.list_chapters())
+        except AppleBooksError as e:
+            logger.warning("chapter count unavailable: %s", e)
+            total_chapters = None
+
+        position = (
+            f"[{chapter.order}/{total_chapters}]" if total_chapters else f"[{chapter.order}]"
+        )
+        return (
+            f"\nCurrent chapter: {position} {chapter.title}"
+            f"\n  Chapter id: {chapter.id}  "
+            f"(pass to get_chapter_content for the text)"
+        )
+
+    # Tier 2: ToC lookup yielded nothing. Peek at the raw position CFI —
+    # sub-section ids still work with get_chapter_content even when the
+    # ToC doesn't carry them.
+    try:
+        bookmark = api.get_current_reading_location(book.id)
+    except AppleBooksError as e:
+        logger.warning("current reading location unavailable: %s", e)
         return ""
 
-    try:
-        content = api.get_book_content(book.id)
-        total_chapters = len(content.list_chapters())
-    except AppleBooksError as e:
-        logger.warning("chapter count unavailable: %s", e)
-        total_chapters = None
+    if (
+        bookmark is not None
+        and getattr(bookmark, "location", None)
+        and bookmark.location.chapter_id
+    ):
+        return (
+            f"\nCurrent chapter id: {bookmark.location.chapter_id}"
+            f"\n  (not in this book's ToC; pass to get_chapter_content for the text)"
+        )
 
-    position = f"[{chapter.order}/{total_chapters}]" if total_chapters else f"[{chapter.order}]"
-    return (
-        f"\nCurrent chapter: {position} {chapter.title}"
-        f"\n  Chapter id: {chapter.id}  "
-        f"(pass to get_chapter_content for the text)"
-    )
+    return ""

--- a/apple_books_mcp/utils.py
+++ b/apple_books_mcp/utils.py
@@ -344,9 +344,8 @@ def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
             f"[{chapter.order}/{total_chapters}]" if total_chapters else f"[{chapter.order}]"
         )
         return (
-            f"\nCurrent chapter: {position} {chapter.title}"
-            f"\n  Chapter id: {chapter.id}  "
-            f"(pass to get_chapter_content for the text)"
+            f"\nCurrent chapter: {position} {chapter.title}  "
+            f'(use get_chapter_content({book.id}, "{chapter.id}") for the text)'
         )
 
     # Tier 2: ToC lookup yielded nothing. Peek at the raw position CFI —
@@ -363,9 +362,10 @@ def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
         and getattr(bookmark, "location", None)
         and bookmark.location.chapter_id
     ):
+        cid = bookmark.location.chapter_id
         return (
-            f"\nCurrent chapter id: {bookmark.location.chapter_id}"
-            f"\n  (not in this book's ToC; pass to get_chapter_content for the text)"
+            f"\nCurrent chapter id: {cid}  "
+            f'(use get_chapter_content({book.id}, "{cid}") for the text)'
         )
 
     return ""

--- a/apple_books_mcp/utils.py
+++ b/apple_books_mcp/utils.py
@@ -1,0 +1,372 @@
+"""Formatting + lookup helpers shared across the MCP tool definitions.
+
+These are package-internal (``_``-prefixed) — not part of the MCP
+surface. Tools in :mod:`server` call them for consistent output
+formatting and for the lookups needed to attach chapter context to
+annotations.
+
+Anything that needs a live :class:`~py_apple_books.PyAppleBooks` instance
+takes it as the first argument (``api``) — keeps this module free of
+singletons and decoupled from ``server`` import order.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, TYPE_CHECKING
+
+from py_apple_books.exceptions import (
+    AppleBooksError,
+    BookNotDownloadedError,
+    DRMProtectedError,
+)
+
+if TYPE_CHECKING:
+    from py_apple_books import PyAppleBooks
+
+logger = logging.getLogger("apple-books-mcp")
+
+
+# --------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------
+
+# Approximate cap on how much chapter text to include in the
+# currently-reading resource. Picked so a typical book chapter fits
+# without blowing up the attached context — ~2000 words / 8000 chars is
+# plenty for Claude to engage with the passage.
+_CURRENT_CHAPTER_CHAR_CAP = 8000
+
+# Max characters shown for a single annotation in list-style outputs.
+# Typical highlights are 1–3 sentences (50–200 chars); this cap keeps
+# each row a single readable line without truncating most.
+_LEAN_TEXT_CAP = 180
+
+
+# --------------------------------------------------------------------------
+# Book / annotation formatting (pure — no apple_books dependency)
+# --------------------------------------------------------------------------
+
+
+def _format_book_with_progress(book) -> str:
+    author = getattr(book, "author", None) or "Unknown Author"
+    title = getattr(book, "title", None) or "Unknown Title"
+    progress = book.format_progress_summary()
+    return f"{title} by {author}\n{progress}"
+
+
+def _get_book_title(annotation) -> str:
+    book = getattr(annotation, "book", None)
+    return getattr(book, "title", None) or "Unknown Book"
+
+
+def _annotation_body(annotation) -> str:
+    """Pick the most informative text for the annotation.
+
+    ``representative_text`` contains the surrounding sentence/paragraph;
+    ``selected_text`` is what the user specifically highlighted. They're
+    often identical, but when they differ the fuller context is usually
+    more useful to the model — while the specific highlight still
+    carries signal about what the reader zeroed in on.
+    """
+    rep = (getattr(annotation, "representative_text", None) or "").strip()
+    sel = (getattr(annotation, "selected_text", None) or "").strip()
+
+    if rep and sel and rep != sel and len(rep) > len(sel) + 20:
+        return f"{rep} ↳ highlighted: \"{sel}\""
+    return rep or sel
+
+
+# ``_format_annotation_with_book`` (legacy) was dropped in v0.7.0 — it
+# used Apple's ``ZFUTUREPROOFING5`` chapter field, which is NULL for
+# most annotations. The grouped/flat formatters below replace it with
+# CFI-based chapter resolution via :func:`_chapter_title_map`.
+
+
+# --------------------------------------------------------------------------
+# Lean annotation rows (id + text + chapter) — for list_annotations tools
+# --------------------------------------------------------------------------
+
+
+def _annotation_chapter_title(annotation, chapter_map: dict) -> str:
+    """Look up the annotation's chapter title from a prefetched map.
+    Returns an empty string when the annotation has no CFI chapter
+    hint or the hinted id isn't in the book's ToC (sub-section case).
+    """
+    if not annotation.location or not annotation.location.chapter_id:
+        return ""
+    return chapter_map.get(annotation.location.chapter_id, "")
+
+
+def _lean_annotation_text(annotation) -> str:
+    """Pick a short, single-line representation of an annotation's
+    highlight text for list-style outputs. Prefers ``selected_text``;
+    falls back to ``representative_text``. Collapses interior whitespace
+    and truncates at :data:`_LEAN_TEXT_CAP`.
+    """
+    sel = (getattr(annotation, "selected_text", None) or "").strip()
+    rep = (getattr(annotation, "representative_text", None) or "").strip()
+    text = sel or rep
+    if not text:
+        return ""
+    text = " ".join(text.split())
+    if len(text) > _LEAN_TEXT_CAP:
+        text = text[: _LEAN_TEXT_CAP].rsplit(" ", 1)[0] + "…"
+    return text
+
+
+def _format_lean_row(annotation, chapter_map: dict) -> str:
+    """Render one annotation as ``[id] text — chapter (ch=chapter_id)``.
+
+    Pieces are dropped in order when unavailable:
+
+    * no text → row shows only id + chapter
+    * no chapter title but a ``chapter_id`` bracket hint → still
+      emits ``(ch=...)`` so Claude can hand it straight to
+      :mcp:`get_chapter_content` without round-tripping through
+      ``list_book_chapters``
+    * neither title nor id (bookmark, DRM, orphan) → bare ``[id]``
+    """
+    text = _lean_annotation_text(annotation)
+    chapter_id = (
+        annotation.location.chapter_id
+        if annotation.location and annotation.location.chapter_id
+        else None
+    )
+    chapter_title = chapter_map.get(chapter_id, "") if chapter_id else ""
+    aid = annotation.id
+
+    parts = [f"[{aid}]"]
+    if text:
+        parts.append(text)
+    if chapter_title:
+        parts.append(f"— {chapter_title}")
+    if chapter_id:
+        parts.append(f"(ch={chapter_id})")
+
+    return " ".join(parts)
+
+
+def _format_note_row(annotation, chapter_map: dict) -> str:
+    """Render a user-note annotation — same shape as ``_format_lean_row``
+    but the note body appears on a second line, prefixed with ``↳``.
+
+    Notes are rarer than highlights and carry the user's own thinking
+    rather than book text, so showing both the highlighted passage and
+    the note keeps the output interpretable without forcing callers
+    into a separate follow-up lookup.
+    """
+    primary = _format_lean_row(annotation, chapter_map)
+    note = (getattr(annotation, "note", None) or "").strip()
+    if not note:
+        return primary
+    note = " ".join(note.split())
+    if len(note) > _LEAN_TEXT_CAP:
+        note = note[: _LEAN_TEXT_CAP].rsplit(" ", 1)[0] + "…"
+    return f"{primary}\n    ↳ note: {note}"
+
+
+def _iso_date(annotation) -> str:
+    """YYYY-MM-DD rendering of the annotation's creation date, or the
+    literal string ``"?"`` when missing."""
+    created = getattr(annotation, "creation_date", None)
+    return created.strftime("%Y-%m-%d") if created else "?"
+
+
+# --------------------------------------------------------------------------
+# Group-by-book formatter — used by the grouped-output annotation tools
+# --------------------------------------------------------------------------
+
+
+def _format_grouped_by_book(
+    api: "PyAppleBooks",
+    annotations,
+    *,
+    empty_message: str = "No annotations.",
+    row_formatter=None,
+    book_header: Optional[callable] = None,
+) -> str:
+    """Render a list of annotations grouped by their originating book.
+
+    Each book gets a header line (``Book Title (Author):`` by default)
+    followed by one :func:`_format_lean_row` per annotation. Orphan
+    annotations (whose ``asset_id`` no longer maps to a book in the
+    library) accumulate into a trailing "Unassigned" section rather
+    than being dropped silently.
+
+    :param api: Facade instance; needed to look up each book's chapter
+        titles for CFI resolution.
+    :param annotations: Iterable of annotations. The caller controls
+        ordering; we preserve it within each book's group.
+    :param empty_message: Returned verbatim when ``annotations`` is
+        empty.
+    :param row_formatter: Callable ``(annotation, chapter_map) -> str``
+        used to render each row. Defaults to
+        :func:`_format_lean_row`; pass :func:`_format_note_row` when
+        annotations carry user notes you want surfaced inline.
+    :param book_header: Optional callable ``(book, annotations) ->
+        str`` that builds the per-book header. Defaults to
+        ``"{title} ({author}):"``. Useful for tools that want to
+        include a count or filter label in the header (e.g.
+        ``{count} yellow highlights``).
+    """
+    annotations = list(annotations)
+    if not annotations:
+        return empty_message
+
+    row_formatter = row_formatter or _format_lean_row
+
+    from collections import defaultdict
+
+    by_book: dict = defaultdict(list)
+    orphans: list = []
+    for anno in annotations:
+        book = getattr(anno, "book", None)
+        if book is None:
+            orphans.append(anno)
+        else:
+            by_book[book.id].append((anno, book))
+
+    chapter_maps = {book_id: _chapter_title_map(api, book_id) for book_id in by_book}
+
+    lines: list = []
+    for book_id, pairs in by_book.items():
+        book = pairs[0][1]
+        annos = [a for a, _ in pairs]
+        if book_header is not None:
+            header = book_header(book, annos)
+        else:
+            author = getattr(book, "author", None) or "Unknown Author"
+            header = f"{book.title} ({author}):"
+        lines.append(f"\n{header}")
+        ch_map = chapter_maps[book_id]
+        for anno in annos:
+            lines.append(f"  {row_formatter(anno, ch_map)}")
+
+    if orphans:
+        lines.append("\nUnassigned (book no longer in library):")
+        for anno in orphans:
+            lines.append(f"  {row_formatter(anno, {})}")
+
+    return "\n".join(lines).lstrip()
+
+
+# --------------------------------------------------------------------------
+# Flat-with-timestamp formatter — for time-oriented tools
+# --------------------------------------------------------------------------
+
+
+def _format_flat_with_timestamp(
+    api: "PyAppleBooks",
+    annotations,
+    *,
+    empty_message: str = "No annotations.",
+) -> str:
+    """Render annotations as a flat, chronologically-oriented list.
+
+    Format per row::
+
+        YYYY-MM-DD [id] text — chapter · Book Title
+
+    The book title appears per-row (not as a group header) because
+    time-oriented tools tend to jump between books, and Claude needs
+    the book context inline. Chapter resolution still uses
+    :func:`_chapter_title_map` — cached across rows so we only parse
+    each EPUB once per call.
+    """
+    annotations = list(annotations)
+    if not annotations:
+        return empty_message
+
+    chapter_map_cache: dict = {}
+
+    def ch_map_for(book_id):
+        if book_id not in chapter_map_cache:
+            chapter_map_cache[book_id] = _chapter_title_map(api, book_id)
+        return chapter_map_cache[book_id]
+
+    lines: list = []
+    for anno in annotations:
+        book = getattr(anno, "book", None)
+        ch_map = ch_map_for(book.id) if book else {}
+        row = _format_lean_row(anno, ch_map)
+        book_suffix = f" · {book.title}" if book else " · (book no longer in library)"
+        lines.append(f"{_iso_date(anno)} {row}{book_suffix}")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# Lookups that need the apple_books instance
+# --------------------------------------------------------------------------
+
+
+def _chapter_title_map(api: "PyAppleBooks", book_id: int) -> dict:
+    """Return ``{chapter_id: chapter_title}`` for a book, or ``{}`` when
+    the book isn't readable (DRM, not downloaded, not an EPUB).
+    """
+    try:
+        content = api.get_book_content(book_id)
+    except (BookNotDownloadedError, DRMProtectedError, AppleBooksError):
+        return {}
+    try:
+        return {c.id: c.title for c in content.list_chapters()}
+    except AppleBooksError:
+        return {}
+
+
+def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
+    """Return a human-readable 'you left off on…' block, or '' if we
+    can't read the book's content (DRM, not downloaded, no bookmark).
+
+    Intentionally soft-failing: a missing chapter shouldn't break the
+    currently_reading resource — the annotations section is still
+    valuable even when content access is unavailable.
+    """
+    try:
+        chapter = api.get_current_reading_chapter(book.id)
+    except BookNotDownloadedError:
+        return (
+            "\nCurrent chapter: not available — this book hasn't been "
+            "downloaded to this Mac. Open it in Apple Books to sync."
+        )
+    except DRMProtectedError:
+        return (
+            "\nCurrent chapter: not readable — this is a DRM-protected "
+            "Apple Books Store purchase; only imported EPUBs expose their "
+            "chapter text."
+        )
+    except AppleBooksError as e:
+        logger.warning("current reading chapter unavailable: %s", e)
+        return ""
+
+    if chapter is None:
+        return ""
+
+    try:
+        content = api.get_book_content(book.id)
+        total_chapters = len(content.list_chapters())
+        full_text = content.get_chapter(chapter.id)
+    except AppleBooksError as e:
+        logger.warning("chapter content unavailable: %s", e)
+        return (
+            f"\nCurrent chapter: [{chapter.order}] {chapter.title}\n"
+            f"(chapter text unavailable)"
+        )
+
+    header = f"\nCurrent chapter: [{chapter.order}/{total_chapters}] {chapter.title}"
+
+    # Some EPUB sections are image-only (cover pages, part dividers that are
+    # rendered as a JPG). Extraction returns an empty string in that case —
+    # skip the "--- chapter text ---" block rather than emit an empty one.
+    if not full_text.strip():
+        return f"{header}\n(This chapter has no extractable text, likely an image-only page.)"
+
+    truncated = full_text[:_CURRENT_CHAPTER_CHAR_CAP]
+    suffix = (
+        f"\n\n…(truncated after {_CURRENT_CHAPTER_CHAR_CAP:,} chars; "
+        f"chapter continues for {len(full_text) - _CURRENT_CHAPTER_CHAR_CAP:,} more)"
+        if len(full_text) > _CURRENT_CHAPTER_CHAR_CAP
+        else ""
+    )
+
+    return f"{header}\n\n--- chapter text ---\n{truncated}{suffix}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "click>=8.1.8",
     "fastmcp>=0.4.1",
-    "py-apple-books>=1.6.0",
+    "py-apple-books>=1.8.0",
 ]
 
 [tool.uv]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,13 +3,14 @@ from datetime import datetime
 from unittest.mock import patch
 from apple_books_mcp.server import (
     list_all_collections, get_collection_books, describe_collection,
-    list_all_books, get_book_annotations, describe_book,
+    list_all_books, describe_book,
     search_books_by_title, search_collections_by_title, get_books_by_genre,
     get_books_in_progress, get_finished_books, get_unstarted_books,
     get_recently_read_books,
-    list_all_annotations, get_highlights_by_color, search_highlighted_text,
-    search_notes, full_text_search, recent_annotations,
-    describe_annotation,
+    list_all_annotations, list_annotations,
+    get_highlights_by_color,
+    search_notes, search_annotations, recent_annotations,
+    describe_annotation, get_annotation_context,
     get_annotations_by_date_range,
     get_library_stats
 )
@@ -38,6 +39,20 @@ class MockBook:
         return {"id": "book1", "title": "Book 1"}
 
 
+class MockLocation:
+    """Mimic py_apple_books.models.location.Location's surface for tests."""
+    def __init__(self, cfi: str = "", chapter_id: str = None, char_range=None):
+        self.cfi = cfi
+        self.chapter_id = chapter_id
+        self.char_range = char_range
+
+    def __bool__(self):
+        return bool(self.cfi)
+
+    def __str__(self):
+        return self.cfi
+
+
 class MockAnnotation:
     def __init__(self):
         self.id = "anno1"
@@ -46,7 +61,12 @@ class MockAnnotation:
 
         self.book = MockBook()
         self.chapter = "Chapter 1"
-        self.location = "Page 1"
+        # Location is now a value object in py-apple-books v1.8.0+; mock
+        # that shape so MCP tools that use ``annotation.location.chapter_id``
+        # behave correctly.
+        self.location = MockLocation(
+            cfi="epubcfi(/6/8[chap1]!/4/2/1:0)", chapter_id="chap1"
+        )
         self.creation_date = datetime(2026, 4, 16, 14, 23, 45)
         self.modification_date = datetime(2026, 4, 16, 14, 24, 0)
 
@@ -60,6 +80,9 @@ class MockAnnotation:
 
 class MockCollection:
     def __init__(self):
+        self.id = "col1"
+        self.title = "Collection 1"
+        self.details = ""
         self._books = [MockBook()]
 
     def __str__(self):
@@ -87,6 +110,9 @@ def mock_apple_books():
         mock.search_annotation_by_note.return_value = [anno]
         mock.search_annotation_by_text.return_value = [anno]
         mock.get_annotation_by_id.return_value = anno
+        mock.get_annotation_surrounding_text.return_value = (
+            "Some preceding text. Test text. Some following text."
+        )
         mock.get_book_by_title.return_value = [book]
         mock.get_collection_by_title.return_value = [MockCollection()]
         mock.get_books_in_progress.return_value = [book]
@@ -123,12 +149,6 @@ def test_list_all_books(mock_apple_books):
     mock_apple_books.list_books.assert_called_once_with(limit=None)
 
 
-def test_get_book_annotations(mock_apple_books):
-    result = get_book_annotations("book1")
-    assert "Test text" in result.text
-    mock_apple_books.get_book_by_id.assert_called_once_with("book1")
-
-
 def test_describe_book(mock_apple_books):
     result = describe_book("book1")
     assert "book1" in result.text
@@ -137,8 +157,41 @@ def test_describe_book(mock_apple_books):
 
 def test_list_all_annotations(mock_apple_books):
     result = list_all_annotations()
-    assert "Test text" in result.text
-    mock_apple_books.list_annotations.assert_called_once_with(limit=None)
+    # New in v0.7.0: lean grouped-by-book output — id + chapter,
+    # no selected_text body. Surrounding text is a follow-up call.
+    assert "[anno1]" in result.text
+    assert "Book 1" in result.text
+    # Ordering defaults to recent-first so heavily-deleted old books
+    # (orphan asset_ids) don't dominate the top of the listing.
+    mock_apple_books.list_annotations.assert_called_once_with(
+        limit=None, order_by="-creation_date"
+    )
+
+
+def test_list_annotations_by_book(mock_apple_books):
+    result = list_annotations("book1")
+    # Book-scoped listing: no book name per row (caller passed book_id),
+    # just the annotation id and chapter.
+    assert "[anno1]" in result.text
+    # The book name should NOT repeat in each row — that's the whole
+    # point of taking book_id as an argument.
+    assert "Book 1" not in result.text
+    mock_apple_books.get_book_by_id.assert_called_with("book1")
+
+
+def test_list_annotations_empty_for_book_with_none(mock_apple_books):
+    # Book exists but has no annotations — should return a friendly
+    # message instead of empty output.
+    book = mock_apple_books.get_book_by_id.return_value
+    book.annotations = []
+    result = list_annotations("book1")
+    assert "No annotations" in result.text
+
+
+def test_list_annotations_unknown_book(mock_apple_books):
+    mock_apple_books.get_book_by_id.side_effect = IndexError()
+    result = list_annotations("99999")
+    assert "No book found" in result.text
 
 
 def test_get_highlights_by_color(mock_apple_books):
@@ -147,20 +200,14 @@ def test_get_highlights_by_color(mock_apple_books):
     mock_apple_books.get_annotations_by_color.assert_called_once_with("yellow", limit=None)
 
 
-def test_search_highlighted_text(mock_apple_books):
-    result = search_highlighted_text("test")
-    assert "Test text" in result.text
-    mock_apple_books.search_annotation_by_highlighted_text.assert_called_once_with("test", limit=None)
-
-
 def test_search_notes(mock_apple_books):
     result = search_notes("note")
     assert "Test text" in result.text
     mock_apple_books.search_annotation_by_note.assert_called_once_with("note", limit=None)
 
 
-def test_full_text_search(mock_apple_books):
-    result = full_text_search("test")
+def test_search_annotations(mock_apple_books):
+    result = search_annotations("test")
     assert "Test text" in result.text
     mock_apple_books.search_annotation_by_text.assert_called_once_with("test", limit=None)
 
@@ -178,7 +225,10 @@ def test_recent_annotations_handles_missing_book(mock_apple_books):
 
     result = recent_annotations()
 
-    assert "Unknown Book" in result.text
+    # Orphaned annotations (asset_id no longer maps to a library book) get
+    # an explicit "no longer in library" suffix instead of silently
+    # disappearing into an "Unknown Book" bucket.
+    assert "no longer in library" in result.text
     mock_apple_books.list_annotations.assert_called_once_with(limit=10, order_by="-creation_date")
 
 
@@ -238,22 +288,29 @@ def test_limit_parameter(mock_apple_books):
     mock_apple_books.get_books_in_progress.assert_called_with(limit=2)
 
 
-def test_annotation_uses_representative_text_when_richer(mock_apple_books):
-    """Representative text (fuller sentence) should surface when it extends the highlight."""
+def test_annotation_lean_row_prefers_selected_text(mock_apple_books):
+    """v0.7.0 list-style tools render lean rows: ``[id] selected — chapter``.
+    The fuller ``representative_text`` stays out of these — callers who want
+    context follow up with ``describe_annotation`` or
+    ``get_annotation_context``."""
     anno = MockAnnotation()
     anno.selected_text = "minus one"
     anno.representative_text = "A caret acts like a minus one in git revision syntax."
     mock_apple_books.list_annotations.return_value = [anno]
 
     result = recent_annotations()
-    assert "A caret acts like a minus one in git revision syntax" in result.text
-    assert 'highlighted: "minus one"' in result.text
+    # Lean output shows the highlight the user actually selected.
+    assert "minus one" in result.text
+    # Representative text is NOT shown inline — that's the whole point of
+    # the lean format.
+    assert "A caret acts like" not in result.text
 
 
-def test_annotation_output_includes_timestamp(mock_apple_books):
-    """Timestamps are required for Claude to cluster annotations into sessions."""
+def test_annotation_output_includes_date(mock_apple_books):
+    """The flat-with-timestamp format leads each row with YYYY-MM-DD so
+    Claude can cluster annotations into reading sessions."""
     result = recent_annotations()
-    assert "2026-04-16T14:23:45" in result.text
+    assert "2026-04-16" in result.text
 
 
 def test_get_annotations_by_date_range(mock_apple_books):
@@ -278,6 +335,36 @@ def test_describe_annotation(mock_apple_books):
     result = describe_annotation("anno1")
     assert "anno1" in result.text
     mock_apple_books.get_annotation_by_id.assert_called_once_with("anno1")
+
+
+def test_get_annotation_context_marks_highlight(mock_apple_books):
+    """The tool wraps the selected_text with guillemets inside the
+    returned window so Claude can see the exact anchor."""
+    result = get_annotation_context(1)
+    assert "«Test text»" in result.text
+    assert "Some preceding text" in result.text
+    assert "Some following text" in result.text
+    mock_apple_books.get_annotation_surrounding_text.assert_called_once_with(
+        1, chars_before=500, chars_after=500
+    )
+
+
+def test_get_annotation_context_empty_degrades(mock_apple_books):
+    """When the backend returns '' (no CFI hint, DRM, etc.) the tool
+    returns an explanatory message instead of an empty response."""
+    mock_apple_books.get_annotation_surrounding_text.return_value = ""
+    # Drop the location so the reason is the missing-chapter-hint path.
+    anno = mock_apple_books.get_annotation_by_id.return_value
+    anno.location = None
+    result = get_annotation_context(1)
+    assert "No surrounding context available" in result.text
+    assert "CFI" in result.text
+
+
+def test_get_annotation_context_unknown_id(mock_apple_books):
+    mock_apple_books.get_annotation_by_id.side_effect = IndexError()
+    result = get_annotation_context(99999)
+    assert "No annotation found with id 99999" in result.text
 
 
 def test_currently_reading_resource_registered():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -378,16 +378,26 @@ def test_currently_reading_resource_registered():
 
 
 def test_currently_reading_resource_content(mock_apple_books):
-    """Reading the resource returns the most recent in-progress book with its annotations."""
+    """The resource is a lean pointer — metadata + ids only, no chapter
+    text, no annotations list. Claude fetches richer context on demand
+    via list_annotations / get_chapter_content / get_annotation_context.
+    """
     import asyncio
     from apple_books_mcp.server import mcp
 
     result = asyncio.run(mcp.read_resource("apple-books://currently-reading"))
     content = result[0].content if hasattr(result[0], "content") else str(result[0])
+
+    # Metadata + ids — still present.
     assert "Currently Reading: Book 1 by Author 1" in content
     assert "In Progress" in content
-    # Annotations should be included
-    assert "Test text" in content
+    assert "Book id: book1" in content
+    # Annotation count is shown, but the highlight bodies are NOT.
+    assert "Highlights in this book: 1" in content
+    assert "Test text" not in content  # the annotation body stays out
+    # Pointer to list_annotations for richer browsing.
+    assert "list_annotations" in content
+
     mock_apple_books.get_books_in_progress.assert_called_with(limit=1, order_by="-last_opened_date")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "apple-books-mcp"
-version = "0.1.6"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },
@@ -43,11 +43,24 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.8" },
     { name = "fastmcp", specifier = ">=0.4.1" },
-    { name = "py-apple-books", specifier = ">=1.4.0" },
+    { name = "py-apple-books", specifier = ">=1.8.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721 },
+]
 
 [[package]]
 name = "certifi"
@@ -77,6 +90,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "ebooklib"
+version = "0.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/85/322e8882a582d4b707220d1929cfb74c125f2ba513991edbce40dbc462de/ebooklib-0.20.tar.gz", hash = "sha256:35e2f9d7d39907be8d39ae2deb261b19848945903ae3dbb6577b187ead69e985", size = 127066 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl", hash = "sha256:fff5322517a37e31c972d27be7d982cc3928c16b3dcc5fd7e8f7c0f5d7bcf42b", size = 40995 },
 ]
 
 [[package]]
@@ -161,6 +187,68 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689 },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892 },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489 },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162 },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247 },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042 },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304 },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578 },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209 },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365 },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654 },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326 },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879 },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048 },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241 },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938 },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728 },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372 },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713 },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874 },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535 },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881 },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305 },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522 },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310 },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799 },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693 },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708 },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737 },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817 },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753 },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071 },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319 },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139 },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195 },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870 },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548 },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866 },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476 },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719 },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890 },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008 },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451 },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135 },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126 },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579 },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206 },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906 },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553 },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458 },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861 },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377 },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701 },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -220,11 +308,15 @@ wheels = [
 
 [[package]]
 name = "py-apple-books"
-version = "1.4.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/06/23c049b292b67dbdf0f4dd7e7476431d44d3e240076327dbc2a4023aa771/py_apple_books-1.4.0.tar.gz", hash = "sha256:5c20891834e3d3c6af71625b9ad98e20a90857f636eabe2790d0613d9e21968c", size = 13970 }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "ebooklib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/3c/6e942d514790bf8f570cfa9e248ef6e0c233af30dd4adb8f539d74abed9f/py_apple_books-1.8.0.tar.gz", hash = "sha256:dc402f61fd351e9d33f9fc16e21c0c33e92fb6f6f21cca28b75dc7a8cf972c1f", size = 39936 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/95/a0d06336126f5e68a6d829ce47f51f49928d550598f99ff8d566096ed8bb/py_apple_books-1.4.0-py3-none-any.whl", hash = "sha256:d1e99b5cf9d6b8d3c020e7143b59f5ddab53381a0d45ae49231da6c7c896cf34", size = 15803 },
+    { url = "https://files.pythonhosted.org/packages/ed/29/9d26710b217340afef0e9f88b4a7dcbbdc2488fe9f05f36b3e1d0683f755/py_apple_books-1.8.0-py3-none-any.whl", hash = "sha256:16c1621df87e77d5ea415a8545a3016bebc9b5bc64a77f1b710c8f8ea89e068e", size = 35054 },
 ]
 
 [[package]]
@@ -339,12 +431,30 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

v0.7.0 turns the MCP surface from a browse-only Apple Books wrapper into a **reading copilot** — Claude can now go from "I read X" to "here's the passage around the highlight, in its native context, with the chapter text one call away."

### New capabilities

**Book content access** (non-DRM EPUBs only — DRM returns a clear error):
- `list_book_chapters(book_id)` — Table of contents with title, order, nesting depth.
- `get_chapter_content(book_id, chapter_id, offset?, max_chars?)` — Plain-text chapter body, with opt-in pagination. Every response ends with an explicit footer showing `offset / end / total / remaining` so Claude can paginate without guessing.
- `get_current_reading_position(book_id)` — The chapter Apple Books auto-bookmarks as "where you are right now" (via CFI).

**Annotation expansion**:
- `get_annotation_context(annotation_id, chars_before=500, chars_after=500)` — Text window around a specific highlight, with the anchor wrapped in `«...»` guillemets so Claude sees exactly what the user marked.

**Reading status**:
- `get_books_in_progress`, `get_finished_books`, `get_unstarted_books`, `get_recently_read_books`.

**Currently-reading MCP resource** (`apple-books://currently-reading`): attachable from Claude Desktop. Bundles the most recent in-progress book + metadata + current chapter text (preview) + recent annotations into one context payload.

### Reshaped annotation tools

- `list_all_annotations`, `search_annotations`, `get_highlights_by_color` now group by book, with per-row format `[id] text — chapter (ch=chapter_id)` so Claude can hand `chapter_id` straight to `get_chapter_content` without round-tripping through the ToC.
- `recent_annotations`, `get_annotations_by_date_range` use flat rows with date + book inline for chronological browsing.
- `list_annotations(book_id, limit)` — per-book view, chapter-ordered.
- `describe_book`, `describe_collection`, `describe_annotation` now emit curated output instead of `__dict__` dumps.

### Renames / removals

| Before | After |
|---|---|
| `get_book_chapter` | `get_chapter_content` (with pagination) |
| `full_text_search` | `search_annotations` |
| `search_highlighted_text` | removed (superseded by `search_annotations`, which OR-matches across highlight + surrounding + note) |
| `get_book_annotations` | removed (superseded by `list_annotations(book_id)`) |

### Internals

- Factored formatters + lookups into `apple_books_mcp/utils.py`.
- Bumped `py-apple-books` dependency to `>=1.8.0` (adds the `Location` CFI value object + backend `get_annotation_surrounding_text`).
- Version bumped to 0.7.0 in both `__init__.py` and `pyproject.toml`.

## Test plan

- [x] `pytest` — 34/34 tests pass, including 3 new tests covering `get_annotation_context`.
- [x] Smoke-tested all 25 tools + 5 prompts + 1 resource against a real Apple Books library (91 books, many in-progress / annotated / DRM / orphan).
- [x] Exercised error paths: unknown ids (book/annotation/collection/chapter), out-of-bounds offsets, invalid `max_chars`, DRM-protected books, iCloud-only books, type=3 bookmarks.
- [x] README diffed against registered tools — zero drift; all stale pre-v0.7.0 names scrubbed from docstrings and prompts.
- [x] End-to-end workflow verified: `list_annotations(book_id)` → pick `(ch=X)` suffix → `get_chapter_content(book_id, X)` → or `get_annotation_context(id)` for a narrower window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)