### PR TITLE
Bump server.json to 0.7.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vgnshiyer/apple-books-mcp",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-books-mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Keep the MCP Registry manifest (`server.json`) in sync with `pyproject.toml` after the v0.7.0 merge. Both `version` fields bumped from `0.6.0` → `0.7.0`. No behavioral change.

## Test plan

- [x] `server.json` is valid JSON.
- [x] Both `version` fields updated (root + `packages[0]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)