### PR TITLE
v0.7.2: tier-3 reading-position fallback + docstring diet

### DIFF
--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 
 @click.command()

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -23,6 +23,7 @@ from apple_books_mcp.utils import (
     _format_lean_row,
     _format_note_row,
     _get_book_title,
+    _resolve_current_chapter,
 )
 
 logger = logging.getLogger("apple-books-mcp")
@@ -327,20 +328,15 @@ def get_recently_read_books(limit: int = 10) -> TextContent:
 @mcp.tool()
 def list_all_annotations(limit: int = None) -> TextContent:
     """
-    Browse all your annotations grouped by book, most recent first.
-    Each row is ``[annotation_id] <text> — <chapter title> (ch=<id>)``.
-    For the surrounding passage of a specific highlight, follow up
-    with ``get_annotation_context(annotation_id)``. For the full
-    chapter, pass the emitted ``ch=<id>`` to ``get_chapter_content``.
-
-    Chapter resolution uses Apple Books' CFI hints; books that can't
-    be opened (DRM, iCloud-only) still appear, just without the
-    chapter suffix.
+    Browse all annotations grouped by book, most recent first. Rows:
+    ``[annotation_id] <text> — <chapter title> (ch=<id>)``. Pass
+    ``ch=<id>`` to ``get_chapter_content`` for the chapter, or call
+    ``get_annotation_context(annotation_id)`` for the passage around
+    a specific highlight.
 
     Args:
-        limit: Maximum number of annotations to return. Applied before
-            grouping; defaults to unlimited, which may produce a very
-            long list on heavily-annotated libraries.
+        limit: Max annotations to return. Unlimited by default — can
+            be very long on heavily-annotated libraries.
     """
     # Default to newest-first — old annotations are often from books
     # the user has since removed from their library (orphan rows), and
@@ -388,17 +384,13 @@ def list_all_annotations(limit: int = None) -> TextContent:
 @mcp.tool()
 def list_annotations(book_id: int, limit: int = None) -> TextContent:
     """
-    List annotations within a specific book. Returns minimal rows —
-    ``[annotation_id] <chapter title>`` — since the caller already
-    scoped the query by book id.
-
-    Ordered by chapter position in the book (reading order), then by
-    creation date for ties. Unresolvable chapters (sub-sections not
-    in the ToC, DRM books) show ``—``.
+    List annotations within a specific book, ordered by chapter
+    position in the book (reading order). Rows are lean —
+    ``[annotation_id] <text> — <chapter> (ch=<id>)``.
 
     Args:
         book_id: The book's numeric ID.
-        limit: Maximum number of annotations to return.
+        limit: Max annotations to return.
     """
     try:
         book = apple_books.get_book_by_id(book_id)
@@ -533,12 +525,9 @@ def recent_annotations(limit: int = 10) -> TextContent:
 @mcp.tool()
 def describe_annotation(annotation_id: str) -> TextContent:
     """
-    Describe a specific annotation in detail — its text, note, book,
-    chapter (with chapter_id for hand-off to ``get_chapter_content``),
-    color, creation date, and raw CFI. Use this when you have an
-    annotation id from one of the listing tools and want the full
-    picture. For just the surrounding paragraph, call
-    ``get_annotation_context`` instead.
+    Describe a specific annotation in detail — text, note, book,
+    chapter, color, creation date. For the passage around the
+    highlight, call ``get_annotation_context`` instead.
 
     Args:
         annotation_id: The annotation's numeric ID.
@@ -606,27 +595,18 @@ def get_annotation_context(
     chars_after: int = 500,
 ) -> TextContent:
     """
-    Return a text window around a single annotation — the passage
-    immediately before and after the user's highlight, snapped to word
-    boundaries. The highlighted text itself is wrapped in guillemets
-    (``«...»``) inside the output so Claude can see the exact anchor.
+    Return the passage around a specific highlight — the text before
+    and after, with the highlight itself wrapped in ``«...»``. Use
+    this to expand on a highlight without fetching the whole chapter.
 
-    Use this to explain or expand on a specific highlight without
-    fetching the whole chapter. For a full-chapter view, follow up with
-    ``get_chapter_content``.
-
-    Only works for non-DRM EPUBs that have been downloaded to this Mac.
-    DRM-protected Apple Books Store purchases, iCloud-only books, and
-    annotations whose CFI has no chapter hint all degrade to a clear
-    "no context available" message.
+    Works for non-DRM EPUBs downloaded to this Mac; degrades with a
+    clear message for DRM-protected books, iCloud-only books, or
+    older annotations that lack the chapter hint.
 
     Args:
-        annotation_id: The annotation's numeric ID (from any of the
-            listing tools).
-        chars_before: Characters of context before the highlight.
-            Default 500.
-        chars_after: Characters of context after the highlight.
-            Default 500.
+        annotation_id: The annotation's numeric ID.
+        chars_before: Chars of context before the highlight. Default 500.
+        chars_after: Chars of context after the highlight. Default 500.
     """
     try:
         anno = apple_books.get_annotation_by_id(annotation_id)
@@ -765,27 +745,18 @@ def get_chapter_content(
     max_chars: int = 10000,
 ) -> TextContent:
     """
-    Return the plain-text content of a specific chapter, paginated by
-    default so a long chapter can't blow up the context window.
+    Return the plain-text content of a chapter, paginated by default
+    to protect the context window. Get ``chapter_id`` from
+    ``list_book_chapters`` or from the ``(ch=...)`` suffix on
+    annotation listing rows. Works for non-DRM EPUBs downloaded to
+    this Mac.
 
-    ``chapter_id`` should come from a prior ``list_book_chapters`` call
-    (or from the ``(ch=...)`` suffix printed on annotation listing rows).
-    It accepts either the ``Chapter.id`` value or the 1-based chapter
-    order rendered as a string (e.g. ``"5"``). Only works for non-DRM
-    EPUBs that have been downloaded to this Mac.
+    Default ``max_chars=10000`` (~2500 words) fits most chapters in
+    one call. Longer chapters return a slice with a footer naming
+    the exact ``offset`` to pass next. ``max_chars=None`` disables
+    pagination.
 
-    Default ``max_chars=10000`` (~2500 words) covers most typical
-    chapters in a single call; chapters under this cap return as
-    ``(full chapter returned: N chars.)``. Longer chapters return the
-    first slice with a pagination footer naming the exact ``offset``
-    to pass next. Raise ``max_chars`` if you're confident the chapter
-    is short, or pass ``max_chars=None`` to get everything in one
-    call (use sparingly — some chapters run to 50k+ chars).
-
-    Every response ends with an explicit footer showing the exact
-    ``offset`` / ``end`` / ``total`` character counts, so you can
-    decide whether to re-call with a new ``offset`` without guessing.
-    Example footers::
+    Every response ends with a footer like one of::
 
         (full chapter returned: 4,872 chars.)
         …(returned chars 0–10000 of 24,311 [10000 chars]. Call again with
@@ -794,14 +765,10 @@ def get_chapter_content(
 
     Args:
         book_id: The book's numeric ID.
-        chapter_id: The chapter identifier or 1-based position.
-        offset: Character offset to start from (0 = start of chapter).
-            Useful for paginating through a long chapter without
-            re-reading the part you've already seen.
-        max_chars: Maximum characters to return in this call. Defaults
-            to 10000 — enough for ~2500 words of reasoning without
-            eating the context. Pass a higher value when you need more
-            in one shot, or ``None`` to return the entire chapter.
+        chapter_id: Chapter identifier, or the 1-based chapter order
+            as a string (e.g. ``"5"``).
+        offset: Character offset to start from. Defaults to 0.
+        max_chars: Max chars to return. Default 10000. ``None`` = no cap.
     """
     try:
         content = apple_books.get_book_content(book_id)
@@ -874,77 +841,84 @@ def get_chapter_content(
 @mcp.tool()
 def get_current_reading_position(book_id: int) -> TextContent:
     """
-    Return the chapter the user last left off reading, based on Apple Books'
-    auto-tracked reading position bookmark. Useful when the caller wants to
-    focus on a specific book rather than the global ``currently-reading``
-    resource.
+    Return where the user last left off reading a book — chapter
+    title and chapter_id, no text. Follow up with
+    ``get_chapter_content`` for the text.
 
-    Returns chapter metadata only. For the chapter text, follow up with
-    ``get_chapter_content``. Only works for non-DRM EPUBs that have been
-    downloaded to this Mac.
-
-    Two-tier resolution: first tries the clean ToC-resolved chapter; if
-    the CFI points to a manifest item the ToC doesn't carry (sub-section
-    or re-numbered spine entry), falls back to emitting just the
-    chapter_id so it's still actionable with ``get_chapter_content``.
+    Works for non-DRM EPUBs downloaded to this Mac. If Apple Books
+    hasn't recorded a position, falls back to inferring from the
+    user's most recent highlight (labeled as such in the output).
 
     Args:
         book_id: The book's numeric ID.
     """
-    # Tier 1: ToC-resolved chapter.
     try:
-        chapter = apple_books.get_current_reading_chapter(book_id)
+        book = apple_books.get_book_by_id(book_id)
+    except IndexError:
+        return TextContent(
+            type="text", text=f"No book found with id {book_id}."
+        )
+
+    try:
+        resolution = _resolve_current_chapter(apple_books, book)
     except BookNotDownloadedError as e:
         return TextContent(type="text", text=f"Book not available: {e}")
     except DRMProtectedError as e:
         return TextContent(type="text", text=f"Book is DRM-protected: {e}")
     except AppleBooksError as e:
         return TextContent(type="text", text=f"Could not resolve position: {e}")
-    except IndexError:
-        return TextContent(
-            type="text", text=f"No book found with id {book_id}."
-        )
 
-    if chapter is not None:
+    if resolution is None:
         return TextContent(
             type="text",
             text=(
-                f"Current chapter: [{chapter.order}] {chapter.title}  "
-                f'(use get_chapter_content({book_id}, "{chapter.id}") for the text)\n'
-                f"  Depth in ToC: {chapter.depth}\n"
-                f"  File: {chapter.href}"
+                "No reading position and no highlights yet — open the "
+                "book to a chapter and read or highlight something, "
+                "then try again."
             ),
         )
 
-    # Tier 2: ToC lookup empty. Peek at the raw position CFI —
-    # sub-section ids still work with get_chapter_content even when the
-    # ToC doesn't carry them. Same fallback used by the
-    # currently-reading resource.
-    try:
-        bookmark = apple_books.get_current_reading_location(book_id)
-    except AppleBooksError as e:
-        logger.warning("current reading location unavailable: %s", e)
-        return TextContent(
-            type="text", text="No reading position recorded for this book yet."
-        )
+    call_hint = (
+        f'(use get_chapter_content({book_id}, "{resolution.chapter_id}") '
+        f"for the text)"
+    )
 
-    if (
-        bookmark is not None
-        and getattr(bookmark, "location", None)
-        and bookmark.location.chapter_id
-    ):
-        cid = bookmark.location.chapter_id
+    if resolution.source == "toc":
         return TextContent(
             type="text",
             text=(
-                f"Current chapter id: {cid}  "
-                f'(use get_chapter_content({book_id}, "{cid}") for the text)'
+                f"Current chapter: [{resolution.order}] {resolution.title}  "
+                f"{call_hint}"
             ),
         )
 
+    if resolution.source == "cfi":
+        return TextContent(
+            type="text",
+            text=(
+                f"Current chapter id: {resolution.chapter_id}  {call_hint}"
+            ),
+        )
+
+    # source == "recent_highlight"
+    label = (
+        "(inferred from your most recent highlight — Apple Books hasn't "
+        "recorded a CFI on the reading bookmark yet)"
+    )
+    if resolution.title:
+        return TextContent(
+            type="text",
+            text=(
+                f"Current chapter: {resolution.title}  {call_hint}\n"
+                f"  {label}"
+            ),
+        )
     return TextContent(
         type="text",
-        text="No reading position recorded for this book yet.",
+        text=(
+            f"Current chapter id: {resolution.chapter_id}  {call_hint}\n"
+            f"  {label}"
+        ),
     )
 
 

--- a/apple_books_mcp/utils.py
+++ b/apple_books_mcp/utils.py
@@ -13,7 +13,8 @@ singletons and decoupled from ``server`` import order.
 from __future__ import annotations
 
 import logging
-from typing import Optional, TYPE_CHECKING
+from datetime import datetime
+from typing import NamedTuple, Optional, TYPE_CHECKING
 
 from py_apple_books.exceptions import (
     AppleBooksError,
@@ -315,32 +316,147 @@ def _chapter_title_map(api: "PyAppleBooks", book_id: int) -> dict:
         return {}
 
 
-def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
-    """Return a compact 'you left off on…' metadata block, or '' if we
-    can't resolve the user's reading position (DRM, not downloaded, no
-    bookmark).
+class _ChapterResolution(NamedTuple):
+    """Result of resolving a book's 'current chapter' with its
+    provenance tier. Consumers render the same data differently
+    depending on ``source`` so we don't claim the bookmark told us
+    something the bookmark didn't actually contain.
 
-    Lean-by-design: emits only the chapter's title, order, and id —
-    never the chapter text. If Claude wants the text, it calls
+    ``chapter_id`` is always usable with ``get_chapter_content``;
+    ``title`` and ``order`` may be None when the CFI points at a
+    manifest item the ToC doesn't carry.
+
+    ``source`` values:
+
+    * ``"toc"`` — Apple Books' reading-position bookmark CFI resolves
+      cleanly to a ToC entry. Highest-fidelity answer.
+    * ``"cfi"`` — The bookmark has a CFI but its ``chapter_id`` isn't
+      in the ToC (sub-section or re-numbered spine entry). Still
+      actionable with ``get_chapter_content``.
+    * ``"recent_highlight"`` — Bookmark exists but has no CFI (Apple
+      Books sometimes writes empty tombstones). We proxy with the
+      user's most recent highlight in this book. Clearly labeled
+      downstream so the caller doesn't mistake it for an authoritative
+      position.
+    """
+
+    chapter_id: str
+    title: Optional[str]
+    order: Optional[int]
+    total_chapters: Optional[int]
+    source: str
+
+
+def _most_recent_highlight_chapter(book) -> Optional[tuple[str, object]]:
+    """Return (chapter_id, annotation) for the most recent annotation
+    in this book whose CFI carries a chapter_id. None if the book has
+    no annotations, or no annotations with a chapter_id.
+    """
+    try:
+        annos = [a for a in book.annotations if a.location and a.location.chapter_id]
+    except Exception as e:
+        logger.warning("book.annotations unavailable: %s", e)
+        return None
+    if not annos:
+        return None
+    annos.sort(
+        key=lambda a: getattr(a, "creation_date", None) or datetime.min,
+        reverse=True,
+    )
+    top = annos[0]
+    return top.location.chapter_id, top
+
+
+def _resolve_current_chapter(
+    api: "PyAppleBooks", book
+) -> Optional[_ChapterResolution]:
+    """Three-tier resolution of 'where is the user in this book?'.
+
+    Raises the book-wide errors (BookNotDownloadedError,
+    DRMProtectedError) — callers render those as the user-facing
+    "not available" / "DRM-protected" messages.
+
+    Returns None if no tier succeeds.
+    """
+    # Tier 1: ToC-resolved chapter.
+    chapter = api.get_current_reading_chapter(book.id)
+    if chapter is not None:
+        try:
+            content = api.get_book_content(book.id)
+            total = len(content.list_chapters())
+        except AppleBooksError as e:
+            logger.warning("chapter count unavailable: %s", e)
+            total = None
+        return _ChapterResolution(
+            chapter_id=chapter.id,
+            title=chapter.title,
+            order=chapter.order,
+            total_chapters=total,
+            source="toc",
+        )
+
+    # Tier 2: raw CFI from reading-position bookmark.
+    try:
+        bookmark = api.get_current_reading_location(book.id)
+    except AppleBooksError as e:
+        logger.warning("current reading location unavailable: %s", e)
+        bookmark = None
+
+    if (
+        bookmark is not None
+        and getattr(bookmark, "location", None)
+        and bookmark.location.chapter_id
+    ):
+        return _ChapterResolution(
+            chapter_id=bookmark.location.chapter_id,
+            title=None,
+            order=None,
+            total_chapters=None,
+            source="cfi",
+        )
+
+    # Tier 3: most-recent-highlight proxy. Only fires when Apple Books
+    # wrote a tombstone bookmark (no CFI) OR wrote no bookmark at all.
+    # Honest labeling downstream makes clear this is a proxy, not the
+    # bookmark itself.
+    proxy = _most_recent_highlight_chapter(book)
+    if proxy is not None:
+        cid, anno = proxy
+        # Enrich with a ToC title if the highlight's CFI happens to
+        # point at a ToC-known chapter (common case).
+        title = None
+        try:
+            content = api.get_book_content(book.id)
+            for c in content.list_chapters():
+                if c.id == cid:
+                    title = c.title
+                    break
+        except AppleBooksError:
+            pass
+        return _ChapterResolution(
+            chapter_id=cid,
+            title=title,
+            order=None,
+            total_chapters=None,
+            source="recent_highlight",
+        )
+
+    return None
+
+
+def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
+    """Return a compact 'you left off on…' metadata block, or '' if no
+    tier yields an answer (DRM, not downloaded, no bookmark and no
+    highlights).
+
+    Lean-by-design: emits only the chapter's title and id — never the
+    chapter text. If Claude wants the text, it calls
     ``get_chapter_content(book_id, chapter_id)`` on demand. This keeps
     the attached resource small so it doesn't dominate the context
     window.
-
-    Two-tier resolution:
-
-    1. Preferred: :meth:`PyAppleBooks.get_current_reading_chapter`
-       gives a full :class:`Chapter` entry when the CFI's chapter_id
-       matches a ToC item.
-    2. Fallback: many EPUBs store the reading-position CFI against a
-       manifest item id that the ToC doesn't list (sub-section, or a
-       re-numbered spine entry). The chapter is still fetchable via
-       :meth:`get_chapter_content` — we just don't have a human
-       title. Peek at the raw Location and emit the id alone so
-       Claude can still hand it off.
     """
-    # Tier 1: try the clean ToC-resolved chapter first.
     try:
-        chapter = api.get_current_reading_chapter(book.id)
+        resolution = _resolve_current_chapter(api, book)
     except BookNotDownloadedError:
         return (
             "\nCurrent chapter: not available — this book hasn't been "
@@ -356,40 +472,34 @@ def _build_current_reading_section(api: "PyAppleBooks", book) -> str:
         logger.warning("current reading chapter unavailable: %s", e)
         return ""
 
-    if chapter is not None:
-        try:
-            content = api.get_book_content(book.id)
-            total_chapters = len(content.list_chapters())
-        except AppleBooksError as e:
-            logger.warning("chapter count unavailable: %s", e)
-            total_chapters = None
-
-        position = (
-            f"[{chapter.order}/{total_chapters}]" if total_chapters else f"[{chapter.order}]"
-        )
-        return (
-            f"\nCurrent chapter: {position} {chapter.title}  "
-            f'(use get_chapter_content({book.id}, "{chapter.id}") for the text)'
-        )
-
-    # Tier 2: ToC lookup yielded nothing. Peek at the raw position CFI —
-    # sub-section ids still work with get_chapter_content even when the
-    # ToC doesn't carry them.
-    try:
-        bookmark = api.get_current_reading_location(book.id)
-    except AppleBooksError as e:
-        logger.warning("current reading location unavailable: %s", e)
+    if resolution is None:
         return ""
 
-    if (
-        bookmark is not None
-        and getattr(bookmark, "location", None)
-        and bookmark.location.chapter_id
-    ):
-        cid = bookmark.location.chapter_id
-        return (
-            f"\nCurrent chapter id: {cid}  "
-            f'(use get_chapter_content({book.id}, "{cid}") for the text)'
-        )
+    call_hint = f'(use get_chapter_content({book.id}, "{resolution.chapter_id}") for the text)'
 
-    return ""
+    if resolution.source == "toc":
+        position = (
+            f"[{resolution.order}/{resolution.total_chapters}]"
+            if resolution.total_chapters
+            else f"[{resolution.order}]"
+        )
+        return f"\nCurrent chapter: {position} {resolution.title}  {call_hint}"
+
+    if resolution.source == "cfi":
+        return f"\nCurrent chapter id: {resolution.chapter_id}  {call_hint}"
+
+    # source == "recent_highlight" — proxy, not the bookmark itself.
+    # Label clearly so the caller knows the provenance.
+    label = (
+        f"(inferred from your most recent highlight — Apple Books hasn't "
+        f"recorded a CFI on the reading bookmark yet)"
+    )
+    if resolution.title:
+        return (
+            f"\nCurrent chapter: {resolution.title}  {call_hint}"
+            f"\n  {label}"
+        )
+    return (
+        f"\nCurrent chapter id: {resolution.chapter_id}  {call_hint}"
+        f"\n  {label}"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.7.1"
+version = "0.7.2"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vgnshiyer/apple-books-mcp",
     "source": "github"
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-books-mcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -514,14 +514,33 @@ def test_get_current_reading_position_tier2_fallback(mock_apple_books):
     assert 'get_chapter_content(175, "chapter001")' in result.text
 
 
-def test_get_current_reading_position_truly_absent(mock_apple_books):
-    """When neither tier-1 nor tier-2 yields a position, the message
-    matches reality ('no position recorded'). Regression test so the
-    tier-2 fallback doesn't make us lie in the other direction."""
+def test_get_current_reading_position_tier3_most_recent_highlight(mock_apple_books):
+    """v0.7.2: when the reading-position bookmark exists but has no
+    CFI (Apple Books sometimes writes empty tombstone bookmarks), OR
+    when no bookmark exists at all, fall back to the chapter of the
+    user's most recent annotation. Clearly labeled as a proxy."""
+    # Tier-1 and tier-2 both empty
     mock_apple_books.get_current_reading_chapter.return_value = None
     mock_apple_books.get_current_reading_location.return_value = None
+    # Book has annotations (the mock MockBook has [MockAnnotation()]
+    # set up in the fixture, whose location.chapter_id = "chap1")
     result = get_current_reading_position(999)
-    assert "No reading position recorded" in result.text
+    # Tier-3 output:
+    assert "chap1" in result.text
+    assert 'get_chapter_content(999, "chap1")' in result.text
+    # Must be clearly labeled as inferred, not claimed as authoritative
+    assert "inferred from your most recent highlight" in result.text
+
+
+def test_get_current_reading_position_truly_truly_absent(mock_apple_books):
+    """All three tiers empty: no bookmark, no CFI, no annotations.
+    Message matches reality and tells the user how to fix it."""
+    mock_apple_books.get_current_reading_chapter.return_value = None
+    mock_apple_books.get_current_reading_location.return_value = None
+    book = mock_apple_books.get_book_by_id.return_value
+    book.annotations = []
+    result = get_current_reading_position(999)
+    assert "No reading position and no highlights yet" in result.text
 
 
 def test_library_stats_separates_orphan_annotations(mock_apple_books):

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "apple-books-mcp"
-version = "0.7.0"
+version = "0.7.2"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Two small improvements, shipped together as a patch.

### 1. Reading-position resolution gains a third tier

Observed on the Patanjali / Yoga Sutras book in @vgnshiyer's library: Apple Books writes a type=3 bookmark row but leaves the CFI empty — a tombstone bookmark. v0.7.1's tier-1 (ToC lookup) and tier-2 (raw CFI) both came up empty, so `get_current_reading_position` returned *"No reading position recorded"* — which is wrong when the user is clearly in the middle of a book with highlights.

v0.7.2 adds tier-3: when the bookmark carries no usable CFI, fall back to the chapter containing the user's most recent highlight in that book. Output is clearly labeled as inferred so nobody mistakes the proxy for an authoritative position:

```
Current chapter: BOOK I  (use get_chapter_content(218, "item5") for the text)
  (inferred from your most recent highlight — Apple Books hasn't recorded a CFI on the reading bookmark yet)
```

The resolver is factored into `utils._resolve_current_chapter` so the tool and the `currently-reading` resource stay in lockstep. Three tiers, one code path.

### 2. Docstring diet

Trimmed implementation leak from the most verbose tool docstrings. Claude's tool catalog gets signal (what the tool does, output shape, args) instead of noise (tier-1/2/3 narration, "Apple Books' CFI hints", backend terminology).

| Tool | Before | After |
|---|---|---|
| `get_chapter_content` | 1873 chars | 1018 chars |
| `get_current_reading_position` | 1047 chars | 376 chars |
| `get_annotation_context` | 908 chars | 560 chars |
| `list_all_annotations` | 655 chars | 403 chars |

## Test plan

- [x] 45/45 tests pass (added 2 new regression tests for tier-3 proxy + truly-empty case)
- [x] Validated against real library: book 218 (Patanjali, tier-3), book 175 (tier-2), book 116 (tier-1). All three tiers render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)