### PR TITLE
Trim prompts to 3 (cadence × zoom taxonomy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ One-click workflows, accessible from Claude Desktop's prompt picker.
 | Prompt | Description | Arguments |
 |--------|-------------|-----------|
 | weekly_digest | Summarize what I've read and highlighted in the past week | days?: int (default: 7) |
-| explain_recent_highlight | Take my most recent highlight and explain what it means | None |
-| what_am_i_reading | Quick snapshot of books I'm currently in the middle of | None |
 | library_snapshot | A reflection on my whole reading life | None |
 | revisit_book | Revisit your notes and highlights from a specific book | book_title: str |
 

--- a/apple_books_mcp/server.py
+++ b/apple_books_mcp/server.py
@@ -1049,30 +1049,6 @@ def weekly_digest(days: int = 7) -> str:
 
 
 @mcp.prompt()
-def explain_recent_highlight() -> str:
-    """Take my most recent highlight and explain what it means."""
-    return (
-        "Call `recent_annotations` with `limit=1` to get my most recent highlight. "
-        "Then explain:\n\n"
-        "1. What the passage is saying, in plain language.\n"
-        "2. Why it likely caught my attention — what's interesting about it.\n"
-        "3. How it fits into the broader argument of the book (if you know the book).\n\n"
-        "Quote the passage first, then explain. Keep it tight."
-    )
-
-
-@mcp.prompt()
-def what_am_i_reading() -> str:
-    """Quick snapshot of books I'm currently in the middle of."""
-    return (
-        "Call `get_books_in_progress` to list what I'm actively reading. For each book, "
-        "give a one-line characterization (title, author, progress, when I last opened "
-        "it). Don't just restate the data — add a sentence about what each book is "
-        "generally about if you know it. End with: \"What would you like to focus on?\""
-    )
-
-
-@mcp.prompt()
 def library_snapshot() -> str:
     """A reflection on my whole reading life — what I've read, what I'm reading, what's stuck."""
     return (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -403,7 +403,7 @@ def test_currently_reading_resource_content(mock_apple_books):
 
 
 def test_prompts_registered():
-    """Verify all 5 prompts are exposed via MCP."""
+    """Verify the 3 curated prompts are exposed via MCP."""
     import asyncio
     from apple_books_mcp.server import mcp
 
@@ -411,8 +411,6 @@ def test_prompts_registered():
     names = {p.name for p in prompts}
     assert names == {
         "weekly_digest",
-        "explain_recent_highlight",
-        "what_am_i_reading",
         "library_snapshot",
         "revisit_book",
     }


### PR DESCRIPTION
## Summary

Cut `what_am_i_reading` and `explain_recent_highlight` from the MCP prompt picker. 5 → 3.

The remaining set maps to a clean cadence × zoom taxonomy — every prompt earns a distinct slot that's hard to get to by typing a natural question:

- **`weekly_digest`** — recurring weekly ritual, time-bounded reflection
- **`library_snapshot`** — occasional "whole shelf" reflection
- **`revisit_book`** — on-demand deep dive into one book

### Why the two cuts

**`what_am_i_reading`** — literally a sentence a user would type naturally ("what am I reading?"), and the `currently-reading` resource already surfaces a richer, attachable version of the same answer. Paid a picker slot for duplicating natural chat + a better surface.

**`explain_recent_highlight`** — subsumed by conversational use of the underlying tools (`recent_annotations` + `get_annotation_context`). Doesn't add unique composition or shape that plain chat can't achieve.

## Test plan

- [x] `pytest` — 45/45 pass (updated `test_prompts_registered` to expect the 3-prompt set)
- [x] README prompts table updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)