### PR TITLE
Bump to 0.7.3

### DIFF
--- a/apple_books_mcp/__init__.py
+++ b/apple_books_mcp/__init__.py
@@ -6,7 +6,7 @@ try:
 except Exception:
     from .server import serve
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 
 @click.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-books-mcp"
-version = "0.7.2"
+version = "0.7.3"
 description = "Model Context Protocol (MCP) server for Apple Books"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vgnshiyer/apple-books-mcp",
     "source": "github"
   },
-  "version": "0.7.2",
+  "version": "0.7.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-books-mcp",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "apple-books-mcp"
-version = "0.7.2"
+version = "0.7.3"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Ships the prompt picker trim from #22 to users.

## Test plan

- [x] Version bumped consistently in `__init__.py`, `pyproject.toml`, `server.json`, `uv.lock`
- [x] No code changes beyond the version bump itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)